### PR TITLE
SSH config file parser: Recognize multiple host names in a "Host" line

### DIFF
--- a/source/ssh-dialog.c
+++ b/source/ssh-dialog.c
@@ -183,7 +183,7 @@ static char ** get_ssh ( unsigned int *length )
 
                 // Add this host name to the list.
                 retv                  = g_realloc ( retv, ( ( *length ) + 2 ) * sizeof ( char* ) );
-                retv[( *length )]     = strdup ( token );
+                retv[( *length )]     = g_strdup ( token );
                 retv[( *length ) + 1] = NULL;
                 ( *length )++;
             }

--- a/source/ssh-dialog.c
+++ b/source/ssh-dialog.c
@@ -151,7 +151,7 @@ static char ** get_ssh ( unsigned int *length )
 
             // Skip empty lines and comment lines. Also skip lines where the
             // keyword is not "Host".
-            if ( ! token || *token == '#' || strcasecmp( token, "Host" ) ) {
+            if ( ! token || *token == '#' || g_ascii_strcasecmp( token, "Host" ) ) {
                 continue;
             }
 
@@ -171,7 +171,7 @@ static char ** get_ssh ( unsigned int *length )
                 // given num_favorites is max 25.
                 int found = 0;
                 for ( unsigned int j = 0; j < num_favorites; j++ ) {
-                    if ( ! strcasecmp ( token, retv[j] ) ) {
+                    if ( ! g_ascii_strcasecmp ( token, retv[j] ) ) {
                         found = 1;
                         break;
                     }

--- a/source/ssh-dialog.c
+++ b/source/ssh-dialog.c
@@ -166,7 +166,7 @@ static char ** get_ssh ( unsigned int *length )
                     continue;
                 }
 
-                // Do we have seen this host name already?
+                // Is this host name already in the history file?
                 // This is a nice little penalty, but doable? time will tell.
                 // given num_favorites is max 25.
                 int found = 0;


### PR DESCRIPTION
Currently, rofi's SSH config file parser only recognizes a *single* host name in a `Host` line when parsing the user's SSH config file. Consequently, the following block yields a single host name, "milliways":

```
Host milliways slartibartfast slarti
    Port 1234
```

However, rofi should present all three host names to the user, i. e. "milliways", "slartibartfast" and "slarti".

This patch modifies the config file parser so that it correctly recognizes multiple host names in a `Host` line. Additionally, it also makes the parser ignore comment lines and negated patterns.