### PR TITLE
Modified the event delay to make rofi more usable

### DIFF
--- a/source/rofi.c
+++ b/source/rofi.c
@@ -190,8 +190,8 @@ static inline MainLoopEvent wait_for_xevent_or_timeout ( Display *display, int x
     FD_ZERO ( &in_fds );
     FD_SET ( x11_fd, &in_fds );
 
-    // Set our timer.  200ms is a decent delay
-    tv.tv_usec = 200000;
+    // Set our timer.  50ms is a decent delay
+    tv.tv_usec = 50000;
     tv.tv_sec  = 0;
     // Wait for X Event or a Timer
     if ( select ( x11_fd + 1, &in_fds, 0, 0, &tv ) == 0 ) {


### PR DESCRIPTION
I use rofi as an application launcher on a daily basis.  The 200ms delay that was introduced has severely hindered the usefulness of the tool because it launches the incorrect command unless I wait for the screen to update.

Basic workflow:

* Launch rofi
* Enter command, i.e. firefox
* Hit enter

At 200ms, rofi will launch a historical command (i.e. pidgin) unless I wait for it to update and display firefox.  I've tried training myself for several days to wait, but it's consistently happening.

Changing the 200ms to 50ms seems to alleviate the issue for me.  I tried 100ms as well, but preferred 50ms at the end of the day.  Now the screen updates as fast as I can type.
