### PR TITLE
Fix bugs relating to hotkeys with modifiers

### DIFF
--- a/source/x11-helper.c
+++ b/source/x11-helper.c
@@ -257,21 +257,14 @@ void x11_grab_key ( Display *display, unsigned int modmask, KeySym key )
     Screen  *screen = DefaultScreenOfDisplay ( display );
     Window  root    = RootWindow ( display, XScreenNumberOfScreen ( screen ) );
     KeyCode keycode = XKeysymToKeycode ( display, key );
-    XUngrabKey ( display, keycode, AnyModifier, root );
 
-    if ( modmask != AnyModifier ) {
-        // bind to combinations of mod and lock masks, so caps and numlock don't confuse people
-        XGrabKey ( display, keycode, modmask, root, True, GrabModeAsync, GrabModeAsync );
-        XGrabKey ( display, keycode, modmask | LockMask, root, True, GrabModeAsync, GrabModeAsync );
+    // bind to combinations of mod and lock masks, so caps and numlock don't confuse people
+    XGrabKey ( display, keycode, modmask, root, True, GrabModeAsync, GrabModeAsync );
+    XGrabKey ( display, keycode, modmask | LockMask, root, True, GrabModeAsync, GrabModeAsync );
 
-        if ( NumlockMask ) {
-            XGrabKey ( display, keycode, modmask | NumlockMask, root, True, GrabModeAsync, GrabModeAsync );
-            XGrabKey ( display, keycode, modmask | NumlockMask | LockMask, root, True, GrabModeAsync, GrabModeAsync );
-        }
-    }
-    else{
-        // nice simple single key bind
-        XGrabKey ( display, keycode, AnyModifier, root, True, GrabModeAsync, GrabModeAsync );
+    if ( NumlockMask ) {
+        XGrabKey ( display, keycode, modmask | NumlockMask, root, True, GrabModeAsync, GrabModeAsync );
+        XGrabKey ( display, keycode, modmask | NumlockMask | LockMask, root, True, GrabModeAsync, GrabModeAsync );
     }
 }
 
@@ -332,8 +325,7 @@ void x11_parse_key ( char *combo, unsigned int *mod, KeySym *key )
         modmask |= Mod5Mask;
     }
 
-    // If no modifier mask is set, allow any modifier.
-    *mod = modmask ? modmask : AnyModifier;
+    *mod = modmask;
 
     // Skip modifier (if exist) and parse key.
     char i = strlen ( combo );


### PR DESCRIPTION
This commit makes the following changes:
1) Fix a bad check introduced in dee0bfb, which checks the modstate of the
event with the keysym of the switcher, not its modmask:

        modstate & ( switchers[i].keysym )

I think it was broken before as well, a binary AND between the two masks
will not tell much about whether they are equal. Instead, the masks are
now checked for equality after removing LockMask and NumlockMask.

2) Stop binding to AnyModifier when none is used. This conflicts with the case
in which we want to bind different modes to the same key, but different
modifiers.

for example, rofi -key-run F2 -key-ssh alt+F2 -key-window shift+F2

Binding F2 with AnyModifier would prevent alt+F2 and shift+F2 from being used.

3) Remove UngrabKey from x11_grab_key to make the above example possible.
4) Refactor search for any of the global keybindings into function locate_switcher.