### PR TITLE
update documentation to new syntax

### DIFF
--- a/doc/rofi-manpage.markdown
+++ b/doc/rofi-manpage.markdown
@@ -259,7 +259,7 @@ daemon listening to specific key-combinations.
     Go into side-bar mode, it will show list of modi at the bottom.
     To show sidebar use:
 
-        rofi -rnow -sidebar-mode -lines 0
+        rofi -show run -sidebar-mode -lines 0
 
 `-lazy-filter-limit` *limit*
 


### PR DESCRIPTION
"-rnow" is now deprecated. "-show run" is the new way to go.