### PR TITLE
alias --help to -h/-help

### DIFF
--- a/source/rofi.c
+++ b/source/rofi.c
@@ -1688,7 +1688,7 @@ int main ( int argc, char *argv[] )
         quiet = TRUE;
     }
     // catch help request
-    if ( find_arg (  "-h" ) >= 0 || find_arg (  "-help" ) >= 0 ) {
+    if ( find_arg (  "-h" ) >= 0 || find_arg (  "-help" ) >= 0 || find_arg(  "--help" ) >= 0 ) {
         help ();
         exit ( EXIT_SUCCESS );
     }


### PR DESCRIPTION
Right now running rofi --help puts it in daemon mode, which can be
confusing for the user. Options in rofi use one dash instead of two, but
I believe an exception should be made for --help.