### PR TITLE
Fixed hotkeys on Russian keyboard layout

### DIFF
--- a/source/keyb.c
+++ b/source/keyb.c
@@ -237,7 +237,9 @@ int abe_test_action ( KeyBindingAction action, unsigned int mask, KeySym key )
     for ( int iter = 0; iter < akb->num_bindings; iter++ ) {
         const KeyBinding * const kb = &( akb->kb[iter] );
         if ( kb->keysym == key ) {
-            if ( ( mask & ~NumlockMask ) == kb->modmask ) {
+            // Bits 13 and 14 of the modifiers together are the group number, and
+            // should be ignored when looking up key bindings
+            if ( ( mask & ~( NumlockMask | (1<<13) | (1<<14) ) ) == kb->modmask ) {
                 return TRUE;
             }
         }


### PR DESCRIPTION
Patch for resolve #169 
According to X11/extensions/XKB.h, modifier mask bits starting at  (1<<13) indicate group state:
```
    /*
     * BuildCoreState: Given a keyboard group and a modifier state,
     *                 construct the value to be reported an event.
     * GroupForCoreState:  Given the state reported in an event,
     *                 determine the keyboard group.
     * IsLegalGroup:   Returns TRUE if 'g' is a valid group index.
     */
#define XkbBuildCoreState(m,g)  ((((g)&0x3)<<13)|((m)&0xff))
#define XkbGroupForCoreState(s) (((s)>>13)&0x3)
#define XkbIsLegalGroup(g)      (((g)>=0)&&((g)<XkbNumKbdGroups))
```
So bits 13 and 14 of the modifiers together are the group number, and should be ignored when looking up key bindings.