### PR TITLE
Fix font bug, use pango_layout_get_size to determine height

### DIFF
--- a/source/textbox.c
+++ b/source/textbox.c
@@ -816,11 +816,10 @@ int textbox_get_estimated_char_height ( void )
     pango_layout_set_font_description ( layout, pfd );
     pango_font_description_free ( pfd );
 
-    // Get width
+    // Get height
     PangoContext     *context = pango_layout_get_context ( layout );
-    PangoFontMetrics *metric  = pango_context_get_metrics ( context, NULL, NULL );
-    int              height   = pango_font_metrics_get_ascent ( metric ) + pango_font_metrics_get_descent ( metric );
-    pango_font_metrics_unref ( metric );
+    int              height;
+    pango_layout_get_size( layout, NULL, &height );
 
     g_object_unref ( layout );
     return ( height ) / PANGO_SCALE + 2 * SIDE_MARGIN;


### PR DESCRIPTION
This commit fixes a bug introduced in 9530f195d1055da8dffbd40d6f3c2f7c73749598, it appears that the information provided by `textbox_get_estimated_char_height` is not correct. Using `Source Code Pro` for example, no matter how small or big I set the font size to be, it always returns the same value: `19456`

The end result is that a large font size produces text that is vertically chopped off, try using ``Mono 20`` to see an example.

I am not a pango expert, but it looks like ``pango_layout_get_size`` is what we want here to get the font height, which is what this commit changes.

Cheers