### PR TITLE
Replace x-terminal-emulator with xdg-terminal

### DIFF
--- a/config/config.def.c
+++ b/config/config.def.c
@@ -78,16 +78,16 @@ Settings config = {
     .menu_hlbg_urgent = "#DC322F",
     .menu_hlbg_active = "#268BD2",
     /** Terminal to use. (for ssh and open in terminal) */
-    .terminal_emulator = "x-terminal-emulator",
+    .terminal_emulator = "xdg-terminal",
     .ssh_client        = "ssh",
     /** Command when executing ssh. */
-    .ssh_command       = "{terminal} -e {ssh-client} {host}",
+    .ssh_command       = "{terminal} '{ssh-client} {host}'",
     /** Command when running */
     .run_command       = "{cmd}",
     /** Command used to list executable commands. empty -> internal */
     .run_list_command  = "",
     /** Command executed when running application in terminal */
-    .run_shell_command = "{terminal} -e {cmd}",
+    .run_shell_command = "{terminal} '{cmd}'",
     /**
      * Location of the window.
      * Enumeration indicating location or gravity of window.

--- a/doc/rofi-manpage.markdown
+++ b/doc/rofi-manpage.markdown
@@ -409,7 +409,7 @@ The following options are further explained in the theming section:
       rofi -terminal xterm
 
   Pattern: *{terminal}*
-  Default: *x-terminal-emulator*
+  Default: *xdg-terminal*
 
 `-ssh-client` *client*
 

--- a/test/helper-test.c
+++ b/test/helper-test.c
@@ -29,15 +29,15 @@ int main ( int argc, char ** argv )
     int  llength    = 0;
     char * test_str = "{host} {terminal} -e bash -c \"{ssh-client} {host}; echo '{terminal} {host}'\"";
     helper_parse_setup ( test_str, &list, &llength, "{host}", "chuck",
-                         "{terminal}", "x-terminal-emulator", NULL );
+                         "{terminal}", "xdg-terminal", NULL );
 
     TASSERT ( llength == 6 );
     TASSERT ( strcmp ( list[0], "chuck" ) == 0 );
-    TASSERT ( strcmp ( list[1], "x-terminal-emulator" ) == 0 );
+    TASSERT ( strcmp ( list[1], "xdg-terminal" ) == 0 );
     TASSERT ( strcmp ( list[2], "-e" ) == 0 );
     TASSERT ( strcmp ( list[3], "bash" ) == 0 );
     TASSERT ( strcmp ( list[4], "-c" ) == 0 );
-    TASSERT ( strcmp ( list[5], "ssh chuck; echo 'x-terminal-emulator chuck'" ) == 0 );
+    TASSERT ( strcmp ( list[5], "ssh chuck; echo 'xdg-terminal chuck'" ) == 0 );
 
     g_strfreev ( list );
 }


### PR DESCRIPTION
x-terminal-emulator is working only on debian and derivates AFAIK. I
think xdg-open is the correct thing to use here since it behaves the
same across all distros.

However I am not 100% sure if my change is correct. Please test it too.