### PR TITLE
Call bash instead of sh for rofi-sensible-terminal

### DIFF
--- a/script/rofi-sensible-terminal
+++ b/script/rofi-sensible-terminal
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This code is released in public domain by Han Boetes <han@mijncomputer.nl>
 # Updated by Dave Davenport <qball@gmpclient.org>


### PR DESCRIPTION
In the script you use 'command -v' which AFAIK is a bash built-in and
thus not available on all shells. Although /bin/sh links to /bin/bash on
many systems it does not on every system. So it is possible that it does
not work.