### PR TITLE
Fix argument quoting when executing shell commands

### DIFF
--- a/config/config.def.c
+++ b/config/config.def.c
@@ -81,13 +81,13 @@ Settings config = {
     .terminal_emulator = "rofi-sensible-terminal",
     .ssh_client        = "ssh",
     /** Command when executing ssh. */
-    .ssh_command       = "{terminal} -e {ssh-client} {host}",
+    .ssh_command       = "{terminal} -e '{ssh-client} {host}'",
     /** Command when running */
     .run_command       = "{cmd}",
     /** Command used to list executable commands. empty -> internal */
     .run_list_command  = "",
     /** Command executed when running application in terminal */
-    .run_shell_command = "{terminal} -e {cmd}",
+    .run_shell_command = "{terminal} -e '{cmd}'",
     /**
      * Location of the window.
      * Enumeration indicating location or gravity of window.


### PR DESCRIPTION
We need this because some shells (such as termite) will not consider everything behind -e as an argument to the -e command but as their own. To  be safe, -e should be in the format: -e "everything for the command in here" as opposed to -e everything -out -here -instead because shells might try to evaluate -out and -here for their own arguments. This fix was tested with xterm and termite.

Before this fix, using termite as a terminal didn't yield expected results.