### PR TITLE
Monitor -2 stands for the focused window

### DIFF
--- a/doc/rofi-manpage.markdown
+++ b/doc/rofi-manpage.markdown
@@ -406,7 +406,9 @@ The following options are further explained in the theming section:
 `-m` *num*
 `-monitor` *num*
 
-    Select (Xinerama) monitor to display **rofi** on.
+    Select (Xinerama) monitor to display **rofi** on. The special number -1 denotes the currently focused monitor, the number -2 denotes the currently focused window (i.e. rofi will be displayed on top of the focused window).
+
+    Default: *-1*
 
 ### PATTERN setting
 

--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -741,9 +741,11 @@ When one entry is left, automatically select this\.
 .
 .IP "" 4
 .
-.nf
-
-Select (Xinerama) monitor to display **rofi** on\.
+.P
+Select (Xinerama) monitor to display **rofi** on\. The special number -1 denotes the currently focused monitor, the number -2 denotes the currently focused window (i.e. rofi will be displayed on top of the focused window).
+.
+.P
+Default: \fI{cmd}\fR
 .
 .fi
 .

--- a/source/x11-helper.c
+++ b/source/x11-helper.c
@@ -241,6 +241,20 @@ void monitor_active ( Display *display, workarea *mon )
                                          -attr.border_width,
                                          -attr.border_width,
                                          &x, &y, &junkwin ) == True ) {
+                if ( config.monitor == -2 ) {
+                    // place the menu above the window
+                    // if some window is focused, place menu above window, else fall
+                    // back to selected monitor.
+                    mon->x = x;
+                    mon->y = y;
+                    mon->w = attr.width;
+                    mon->h = attr.height;
+                    mon->t = attr.border_width;
+                    mon->b = attr.border_width;
+                    mon->l = attr.border_width;
+                    mon->r = attr.border_width;
+                    return;
+                }
                 monitor_dimensions ( display, screen, x, y, mon );
                 return;
             }


### PR DESCRIPTION
When setting rofi's monitor to -2, rofi is placed over the focused
window.

This is in particular useful for window-related scripts, e.g. actions on that menu (moving to different desktop) or menus that offer some further way of text input.