### PR TITLE
Fast ascii filtering

### DIFF
--- a/include/helper.h
+++ b/include/helper.h
@@ -102,7 +102,7 @@ int find_arg ( const char * const key );
  *
  * @returns 1 when matches, 0 otherwise
  */
-int token_match ( char **tokens, const char *input, int case_sensitive,
+int token_match ( char **tokens, const char *input, int not_ascii, int case_sensitive,
                   __attribute__( ( unused ) ) unsigned int index,
                   __attribute__( ( unused ) ) Switcher * data );
 
@@ -152,4 +152,11 @@ char helper_parse_char ( const char *arg );
  * Set the application arguments.
  */
 void cmd_set_arguments ( int argc, char **argv );
+
+/**
+ * @param str a UTF8 string
+ * @return 1 if the string contains any non-ascii codepoints
+ */
+int is_not_ascii ( const char *str );
+
 #endif // ROFI_HELPER_H

--- a/include/helper.h
+++ b/include/helper.h
@@ -16,7 +16,7 @@ int helper_parse_setup ( char * string, char ***output, int *length, ... );
 /**
  * Implementation of fgets with custom separator.
  */
-char* fgets_s ( char* s, int n, FILE *iop, char sep );
+char* fgets_s ( char* s, unsigned int n, FILE *iop, char sep );
 
 /**
  * @param token The string for which we want a collation key.

--- a/include/rofi.h
+++ b/include/rofi.h
@@ -78,7 +78,7 @@ typedef enum
  *
  * @returns 1 when it matches, 0 if not.
  */
-typedef int ( *menu_match_cb )( char **tokens, const char *input, int case_sensitive, unsigned int index, Switcher *data );
+typedef int ( *menu_match_cb )( char **tokens, const char *input, int not_ascii, int case_sensitive, unsigned int index, Switcher *data );
 
 /**
  * @param sw the Switcher to show.

--- a/source/dialogs/combi.c
+++ b/source/dialogs/combi.c
@@ -169,7 +169,7 @@ static SwitcherMode combi_mode_result ( int mretv, char **input, unsigned int se
     }
     return MODE_EXIT;
 }
-static int combi_mode_match ( char **tokens, const char *input,
+static int combi_mode_match ( char **tokens, const char *input, int not_ascii,
                               int case_sensitive, unsigned int index, Switcher *sw )
 {
     CombiModePrivateData *pd = sw->private_data;
@@ -178,13 +178,13 @@ static int combi_mode_match ( char **tokens, const char *input,
         if ( index >= pd->starts[i] && index < ( pd->starts[i] + pd->lengths[i] ) ) {
             if ( tokens && input[0] && tokens[0][0] == '!' ) {
                 if ( tokens[0][1] == pd->switchers[i]->name[0] ) {
-                    return pd->switchers[i]->token_match ( &tokens[1], input, case_sensitive,
+                    return pd->switchers[i]->token_match ( &tokens[1], input, not_ascii, case_sensitive,
                                                            index - pd->starts[i], pd->switchers[i] );
                 }
                 return 0;
             }
             else {
-                return pd->switchers[i]->token_match ( tokens, input, case_sensitive,
+                return pd->switchers[i]->token_match ( tokens, input, not_ascii, case_sensitive,
                                                        index - pd->starts[i], pd->switchers[i] );
             }
         }

--- a/source/dialogs/dmenu.c
+++ b/source/dialogs/dmenu.c
@@ -59,20 +59,32 @@ typedef struct _DmenuModePrivateData
 
 static char **get_dmenu ( unsigned int *length )
 {
-    char buffer[1024];
+    const unsigned int buf_size = 1024;
+    char buffer[buf_size];
     char **retv = NULL;
+    char *buffer_end = NULL;
+    unsigned int rvlength = 1;
 
     *length = 0;
 
-    while ( fgets_s ( buffer, 1024, stdin, (char) config.separator ) != NULL ) {
-        retv                  = g_realloc ( retv, ( ( *length ) + 2 ) * sizeof ( char* ) );
-        retv[( *length )]     = g_strdup ( buffer );
-        retv[( *length ) + 1] = NULL;
+    while ( ( buffer_end = fgets_s ( buffer, buf_size, stdin, (char) config.separator ) ) != NULL ) {
+        if (rvlength < (*length + 2)) {
+          rvlength *= 2;
+          retv      = g_realloc ( retv, ( rvlength ) * sizeof ( char* ) );
+        }
+
+        size_t blength = buffer_end - &(buffer[0]);
+
+        char *copy = g_malloc( blength + 1 );
+        memcpy(copy, buffer, blength);
 
         // Filter out line-end.
-        if ( retv[( *length )][strlen ( buffer ) - 1] == '\n' ) {
-            retv[( *length )][strlen ( buffer ) - 1] = '\0';
+        if ( copy[blength] == '\n' ) {
+            copy[blength] = '\0';
         }
+
+        retv[( *length )]     = copy;
+        retv[( *length ) + 1] = NULL;
 
         ( *length )++;
         // Stop when we hit 2³¹ entries.
@@ -80,7 +92,7 @@ static char **get_dmenu ( unsigned int *length )
             return retv;
         }
     }
-
+    retv      = g_realloc ( retv, ( *length + 1 ) * sizeof ( char* ) );
     return retv;
 }
 

--- a/source/dialogs/dmenu.c
+++ b/source/dialogs/dmenu.c
@@ -316,7 +316,7 @@ int dmenu_switcher_dialog ( void )
         char         **tokens = tokenize ( select, config.case_sensitive );
         unsigned int i        = 0;
         for ( i = 0; i < cmd_list_length; i++ ) {
-            if ( token_match ( tokens, cmd_list[i], config.case_sensitive, 0, NULL ) ) {
+            if ( token_match ( tokens, cmd_list[i], is_not_ascii(cmd_list[i]), config.case_sensitive, 0, NULL ) ) {
                 pd->selected_line = i;
                 break;
             }

--- a/source/dialogs/window.c
+++ b/source/dialogs/window.c
@@ -322,6 +322,7 @@ typedef struct _SwitcherModePrivateData
 } SwitcherModePrivateData;
 
 static int window_match ( char **tokens, __attribute__( ( unused ) ) const char *input,
+                          __attribute__( ( unused) ) int not_ascii,
                           int case_sensitive, unsigned int index, Switcher *sw )
 {
     SwitcherModePrivateData *rmpd = (SwitcherModePrivateData *) sw->private_data;
@@ -338,19 +339,19 @@ static int window_match ( char **tokens, __attribute__( ( unused ) ) const char 
             // e.g. when searching 'title element' and 'class element'
             char *ftokens[2] = { tokens[j], NULL };
             if ( !test && c->title[0] != '\0' ) {
-                test = token_match ( ftokens, c->title, case_sensitive, 0, NULL );
+                test = token_match ( ftokens, c->title, is_not_ascii(c->title), case_sensitive, 0, NULL );
             }
 
             if ( !test && c->class[0] != '\0' ) {
-                test = token_match ( ftokens, c->class, case_sensitive, 0, NULL );
+                test = token_match ( ftokens, c->class, is_not_ascii(c->title), case_sensitive, 0, NULL );
             }
 
             if ( !test && c->role[0] != '\0' ) {
-                test = token_match ( ftokens, c->role, case_sensitive, 0, NULL );
+                test = token_match ( ftokens, c->role, is_not_ascii(c->title), case_sensitive, 0, NULL );
             }
 
             if ( !test && c->name[0] != '\0' ) {
-                test = token_match ( ftokens, c->name, case_sensitive, 0, NULL );
+                test = token_match ( ftokens, c->name, is_not_ascii(c->title), case_sensitive, 0, NULL );
             }
 
             if ( test == 0 ) {

--- a/source/dialogs/window.c
+++ b/source/dialogs/window.c
@@ -343,15 +343,15 @@ static int window_match ( char **tokens, __attribute__( ( unused ) ) const char 
             }
 
             if ( !test && c->class[0] != '\0' ) {
-                test = token_match ( ftokens, c->class, is_not_ascii(c->title), case_sensitive, 0, NULL );
+                test = token_match ( ftokens, c->class, is_not_ascii(c->class), case_sensitive, 0, NULL );
             }
 
             if ( !test && c->role[0] != '\0' ) {
-                test = token_match ( ftokens, c->role, is_not_ascii(c->title), case_sensitive, 0, NULL );
+                test = token_match ( ftokens, c->role, is_not_ascii(c->role), case_sensitive, 0, NULL );
             }
 
             if ( !test && c->name[0] != '\0' ) {
-                test = token_match ( ftokens, c->name, is_not_ascii(c->title), case_sensitive, 0, NULL );
+                test = token_match ( ftokens, c->name, is_not_ascii(c->name), case_sensitive, 0, NULL );
             }
 
             if ( test == 0 ) {

--- a/source/helper.c
+++ b/source/helper.c
@@ -44,6 +44,10 @@
 static int  stored_argc   = 0;
 static char **stored_argv = NULL;
 
+// TODO: is this safe?
+#define NON_ASCII_NON_NULL( x ) ( ((x) < 0) )
+#define ASCII_NON_NULL( x ) ( ((x) > 0) )
+
 void cmd_set_arguments ( int argc, char **argv )
 {
     stored_argc = argc;
@@ -316,7 +320,7 @@ static void advance_unicode_glyph( char** token_in, char** input_in ) {
   char *token = *token_in;
   char *input = *input_in;
 
-  while (*token < 0) {
+  while (NON_ASCII_NON_NULL(*token)) {
     token++;
   }
 
@@ -534,7 +538,7 @@ void config_sanity_check (  )
 
 int is_not_ascii ( const char * str )
 {
-   while (*str > 0) {
+   while (ASCII_NON_NULL(*str)) {
      str++;
    }
    if (*str) return 1;

--- a/source/helper.c
+++ b/source/helper.c
@@ -52,7 +52,7 @@ void cmd_set_arguments ( int argc, char **argv )
 /**
  *  `fgets` implementation with custom separator.
  */
-char* fgets_s ( char* s, int n, FILE *iop, char sep )
+char* fgets_s ( char* s, unsigned int n, FILE *iop, char sep )
 {
     // Map these to registers.
     register int c = EOF;
@@ -72,7 +72,7 @@ char* fgets_s ( char* s, int n, FILE *iop, char sep )
     *cs = '\0';
     // if last read was end of file and current index is start, we are done:
     // Return NULL.
-    return ( c == EOF && cs == s ) ? NULL : s;
+    return ( c == EOF && cs == s ) ? NULL : cs;
 }
 
 /**

--- a/source/helper.c
+++ b/source/helper.c
@@ -351,8 +351,6 @@ static int fuzzy_token_match ( char **tokens, const char *input, __attribute__( 
 
     // this could perhaps be a bit more efficient by iterating over all the tokens at once.
 
-    fprintf(stderr, "fz match %s %d\n", input, not_ascii);
-
     if ( tokens ) {
         char *compk = not_ascii ? token_collate_key ( input, case_sensitive ) : (char *) input;
         for ( int j = 0; match && tokens[j]; j++ ) {

--- a/source/rofi.c
+++ b/source/rofi.c
@@ -244,6 +244,7 @@ typedef struct MenuState
     unsigned int *selected_line;
     MenuReturn   retv;
     char         **lines;
+    int          *lines_not_ascii;
     int          line_height;
 }MenuState;
 
@@ -307,6 +308,8 @@ static void menu_free_state ( MenuState *state )
     g_free ( state->boxes );
     g_free ( state->line_map );
     g_free ( state->distance );
+
+    g_free ( state->lines_not_ascii );
 }
 
 /**
@@ -724,7 +727,7 @@ static void menu_refilter ( MenuState *state )
 
         // input changed
         for ( unsigned int i = 0; i < state->num_lines; i++ ) {
-            int match = state->sw->token_match ( tokens, state->lines[i], config.case_sensitive, i, state->sw );
+            int match = state->sw->token_match ( tokens, state->lines[i], state->lines_not_ascii[i], config.case_sensitive, i, state->sw );
 
             // If each token was matched, add it to list.
             if ( match ) {
@@ -749,6 +752,7 @@ static void menu_refilter ( MenuState *state )
         }
         state->filtered_lines = state->num_lines;
     }
+
     state->selected = MIN ( state->selected, state->filtered_lines - 1 );
 
     if ( config.auto_select == TRUE && state->filtered_lines == 1 && state->num_lines > 1 ) {
@@ -1013,6 +1017,14 @@ MenuReturn menu ( Switcher *sw, char **input, char *prompt, unsigned int *select
     };
     // Request the lines to show.
     state.lines = sw->get_data ( &( state.num_lines ), sw );
+    state.lines_not_ascii = g_malloc0_n( state.num_lines, sizeof( int ) );
+
+    // find out which lines contain non-ascii codepoints, so we can be faster in some cases.
+
+    for (unsigned int line = 0; state.lines[line]; line++) {
+      state.lines_not_ascii[line] = is_not_ascii(state.lines[line]);
+    }
+
     if ( next_pos ) {
         *next_pos = *selected_line;
     }


### PR DESCRIPTION
I've done something again around the collation speed thing. Changes are:

 - in `menu()`, every input string is scanned for non-ascii codepoints.
 - this is to populate an array `lines_not_ascii` in `MenuState`
 - matching functions are supplied with an extra `not_ascii` parameter to tell them whether a particular line of input needs collating and case-folding or not

I haven't made it work in flex yet, because the flex rule will need rewriting a little (there is no strcasechr in the standard library to use in case-insensitive ascii mode).

Compared to the pre-collation approach I did before this:
 - doesn't store an extra copy of the input in memory; instead we have 1 int extra per input
 - doesn't add any noticeable startup time (the scan for non-ascii lines takes about a microsecond for half a million lines)

When most of the input is ascii it reduces the filtering time by about a thousandfold.

I've also very marginally improved the dmenu read speed by reducing the number of strlens and mallocs it does a little, so that you get to the menu slightly quicker.