### PR TITLE
Add -no-parse-known-hosts option

### DIFF
--- a/config/config.def.c
+++ b/config/config.def.c
@@ -126,6 +126,8 @@ Settings config = {
     .auto_select       = FALSE,
     /** Parse /etc/hosts file in ssh view. */
     .parse_hosts       = FALSE,
+    /** Parse ~/.ssh/known_hosts file in ssh view. */
+    .parse_known_hosts = TRUE,
     /** Modi to combine into one view. */
     .combi_modi        = "window,run",
     /** Fuzzy matching. */

--- a/doc/rofi-manpage.markdown
+++ b/doc/rofi-manpage.markdown
@@ -52,6 +52,7 @@
 [ -dump-xresources ]
 [ -auto-select ]
 [ -parse-hosts ]
+[ -no-parse-known-hosts ]
 [ -combi-modi *mode1,mode2* ]
 [ -normal-window ]
 [ -fake-transparency ]
@@ -457,6 +458,15 @@ Default: *{terminal} -e {ssh-client} {host}*
 `-parse-hosts`
 
 Parse the `/etc/hosts` file for entries.
+
+Default: *disabled*
+
+`-parse-known-hosts`
+`-no-parse-known-hosts`
+
+Parse the `~/.ssh/known_hosts` file for entries.
+
+Default: *enabled*
 
 ### Run settings
 

--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -7,7 +7,7 @@
 \fBrofi\fR \- A window switcher, run launcher, ssh dialog and dmenu replacement
 .
 .SH "SYNOPSIS"
-\fBrofi\fR [ \-width \fIpct_scr\fR ] [ \-lines \fIlines\fR ] [ \-columns \fIcolumns\fR ] [ \-font \fIpangofont\fR ] [ \-fg \fIcolor\fR ] [ \-fg\-urgent \fIcolor\fR ] [ \-fg\-active \fIcolor\fR ] [ \-bg\-urgent \fIcolor\fR ] [ \-bg\-active \fIcolor\fR ] [ \-bg \fIcolor\fR ] [ \-bgalt \fIcolor\fR ] [ \-hlfg \fIcolor\fR ] [ \-hlbg \fIcolor\fR ] [ \-key\-\fBmode\fR \fIcombo\fR ] [ \-terminal \fIterminal\fR ] [ \-location \fIposition\fR ] [ \-fixed\-num\-lines ] [ \-padding \fIpadding\fR ] [ \-opacity \fIopacity%\fR ] [ \-display \fIdisplay\fR ] [ \-bc \fIcolor\fR ] [ \-bw \fIwidth\fR ] [ \-dmenu [ \-p \fIprompt\fR ] [ \-sep \fIseparator\fR ] [ \-l \fIselected line\fR ] [ \-mesg ] [ \-select ] ] [ \-filter \fIfilter\fR ] [ \-ssh\-client \fIclient\fR ] [ \-ssh\-command \fIcommand\fR ] [ \-disable\-history ] [ \-levenshtein\-sort ] [ \-case\-sensitive ] [ \-show \fImode\fR ] [ \-modi \fImode1,mode2\fR ] [ \-eh \fIelement height\fR ] [ \-lazy\-filter\-limit \fIlimit\fR ] [ \-e \fImessage\fR] [ \-a \fIrow\fR ] [ \-u \fIrow\fR ] [ \-pid \fIpath\fR ] [ \-now ] [ \-rnow ] [ \-snow ] [ \-version ] [ \-help] [ \-dump\-xresources ] [ \-auto\-select ] [ \-parse\-hosts ] [ \-combi\-modi \fImode1,mode2\fR ] [ \-normal\-window ] [ \-fake\-transparency ] [ \-quiet ] [ \-glob ] [ \-tokenize ]
+\fBrofi\fR [ \-width \fIpct_scr\fR ] [ \-lines \fIlines\fR ] [ \-columns \fIcolumns\fR ] [ \-font \fIpangofont\fR ] [ \-fg \fIcolor\fR ] [ \-fg\-urgent \fIcolor\fR ] [ \-fg\-active \fIcolor\fR ] [ \-bg\-urgent \fIcolor\fR ] [ \-bg\-active \fIcolor\fR ] [ \-bg \fIcolor\fR ] [ \-bgalt \fIcolor\fR ] [ \-hlfg \fIcolor\fR ] [ \-hlbg \fIcolor\fR ] [ \-key\-\fBmode\fR \fIcombo\fR ] [ \-terminal \fIterminal\fR ] [ \-location \fIposition\fR ] [ \-fixed\-num\-lines ] [ \-padding \fIpadding\fR ] [ \-opacity \fIopacity%\fR ] [ \-display \fIdisplay\fR ] [ \-bc \fIcolor\fR ] [ \-bw \fIwidth\fR ] [ \-dmenu [ \-p \fIprompt\fR ] [ \-sep \fIseparator\fR ] [ \-l \fIselected line\fR ] [ \-mesg ] [ \-select ] ] [ \-filter \fIfilter\fR ] [ \-ssh\-client \fIclient\fR ] [ \-ssh\-command \fIcommand\fR ] [ \-disable\-history ] [ \-levenshtein\-sort ] [ \-case\-sensitive ] [ \-show \fImode\fR ] [ \-modi \fImode1,mode2\fR ] [ \-eh \fIelement height\fR ] [ \-lazy\-filter\-limit \fIlimit\fR ] [ \-e \fImessage\fR] [ \-a \fIrow\fR ] [ \-u \fIrow\fR ] [ \-pid \fIpath\fR ] [ \-now ] [ \-rnow ] [ \-snow ] [ \-version ] [ \-help] [ \-dump\-xresources ] [ \-auto\-select ] [ \-parse\-hosts ] [ \-no\-parse\-known\-hosts ] [ \-combi\-modi \fImode1,mode2\fR ] [ \-normal\-window ] [ \-fake\-transparency ] [ \-quiet ] [ \-glob ] [ \-tokenize ]
 .
 .SH "DESCRIPTION"
 \fBrofi\fR is an X11 popup window switcher, run dialog, dmenu replacement and more\. It focuses on being fast to use and have minimal distraction\. It supports keyboard and mouse navigation, type to filter, tokenized search and more\.
@@ -785,6 +785,18 @@ Default: \fI{terminal} \-e {ssh\-client} {host}\fR
 .
 .P
 Parse the \fB/etc/hosts\fR file for entries\.
+.
+.P
+Default: \fIdisabled\fR
+.
+.P
+\fB\-parse\-known\-hosts\fR \fB\-no\-parse\-known\-hosts\fR
+.
+.P
+Parse the \fB~/\.ssh/known_hosts\fR file for entries\.
+.
+.P
+Default: \fIenabled\fR
 .
 .SS "Run settings"
 \fB\-run\-command\fR \fIcmd\fR

--- a/include/rofi.h
+++ b/include/rofi.h
@@ -226,6 +226,8 @@ typedef struct _Settings
     unsigned int   auto_select;
     /** Hosts file parsing */
     unsigned int   parse_hosts;
+    /** Knonw_hosts file parsing */
+    unsigned int   parse_known_hosts;
     /** Combi Switchers */
     char           *combi_modi;
     /** Fuzzy match */

--- a/source/dialogs/ssh.c
+++ b/source/dialogs/ssh.c
@@ -234,7 +234,9 @@ static char ** get_ssh (  unsigned int *length )
     g_free ( path );
     num_favorites = ( *length );
 
-    retv = read_known_hosts_file ( retv, length );
+    if ( config.parse_known_hosts == TRUE ) {
+        retv = read_known_hosts_file ( retv, length );
+    }
     if ( config.parse_hosts == TRUE ) {
         retv = read_hosts_file ( retv, length );
     }

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -121,6 +121,7 @@ static XrmOption xrmOptions[] = {
     { xrm_SNumber, "eh",                   { .snum = &config.element_height          }, NULL, "Row height (in chars)"                         },
     { xrm_Boolean, "auto-select",          { .num  = &config.auto_select             }, NULL, "Enable auto select mode"                       },
     { xrm_Boolean, "parse-hosts",          { .num  = &config.parse_hosts             }, NULL, "Parse hosts file for ssh mode"                 },
+    { xrm_Boolean, "parse-known-hosts",    { .num  = &config.parse_known_hosts       }, NULL, "Parse known_hosts file for ssh mode"           },
     { xrm_String,  "combi-modi",           { .str  = &config.combi_modi              }, NULL, "Set the modi to combine in combi mode"         },
     { xrm_Boolean, "fuzzy",                { .num  = &config.fuzzy                   }, NULL, "Do a more fuzzy matching"                      },
     { xrm_Boolean, "glob",                 { .num  = &config.glob                    }, NULL, "Use glob matching"                             },


### PR DESCRIPTION
This option disables parsing of ~/.ssh/known_hosts.
For humans who like to keep the list of available servers clean. Also useful if you use aliases for the servers in ~/.ssh/config.

The previous default of always parsing known_hosts is not changed.