### PR TITLE
Initialize locale upon startup.

### DIFF
--- a/source/rofi.c
+++ b/source/rofi.c
@@ -34,6 +34,7 @@
 #include <signal.h>
 #include <errno.h>
 #include <time.h>
+#include <locale.h>
 #include <X11/X.h>
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
@@ -2321,6 +2322,10 @@ int main ( int argc, char *argv[] )
     display_str = getenv ( "DISPLAY" );
     find_arg_str (  "-display", &display_str );
 
+    if ( setlocale ( LC_ALL, "" ) == NULL ) {
+        fprintf ( stderr, "Failed to set locale.\n" );
+        return EXIT_FAILURE;
+    }
     if ( !XSupportsLocale () ) {
         fprintf ( stderr, "X11 does not support locales\n" );
         return 11;


### PR DESCRIPTION
It seems that Xlib input contexts assume a C locale when the locale
hasn’t been initialized from the environment before the input context
is created. Inter alia, this will lead to Xlib reading the .XCompose
defintion file as ISO-8859-1, which will result in mojibake when
composing characters in a UTF-8 environment (cf. #268).

I don’t know much C, so this might not be the right way.