### PR TITLE
config: quote terminal command-line when invoking ssh.

### DIFF
--- a/config/config.def.c
+++ b/config/config.def.c
@@ -81,7 +81,7 @@ Settings config = {
     .terminal_emulator = "rofi-sensible-terminal",
     .ssh_client        = "ssh",
     /** Command when executing ssh. */
-    .ssh_command       = "{terminal} -e {ssh-client} {host}",
+    .ssh_command       = "{terminal} -e '{ssh-client} {host}'",
     /** Command when running */
     .run_command       = "{cmd}",
     /** Command used to list executable commands. empty -> internal */


### PR DESCRIPTION
At least termite will disregard {host} unless it’s quoted
as part of the argument to `-e`, and will immediately
exit after calling ssh without any arguments.