### PR TITLE
added optional history; normalized variable names

### DIFF
--- a/Examples/rofi-file-browser.sh
+++ b/Examples/rofi-file-browser.sh
@@ -1,46 +1,98 @@
 #!/usr/bin/env bash
 
-EDITOR=xdg-open
+# Various options for the file browser script:
+ROFI_FB_GENERIC_FO="xdg-open" # command used for opening the selection
+ROFI_FB_PREV_LOC_FILE=~/.local/share/rofi/rofi_fb_prevloc
+ROFI_FB_HISTORY_FILE=~/.local/share/rofi/rofi_fb_history 
+ROFI_FB_HISTORY_MAXCOUNT=5 # maximum number of history entries
+# Comment the next variable to always start in the last visited directory,
+# otherwise rofi_fb will start in the specified directory:
+ROFI_FB_START_DIR=$HOME # starting directory
+# Uncomment the following line to disable history:
+# ROFI_FB_NO_HISTORY=1
 
-CUR_DIR=$PWD
 
-PREV_LOC_FILE=~/.rofi_fb_prevloc
-
-# Read last location, otherwise we default to PWD.
-if [ -f "${PREV_LOC_FILE}" ]
+# Beginning of the script:
+# Create the directory for the files of the script
+if [ ! -d $(dirname "${ROFI_FB_PREV_LOC_FILE}") ]
 then
-    CUR_DIR=$(cat "${PREV_LOC_FILE}") 
+    mkdir -p "$(dirname "${ROFI_FB_PREV_LOC_FILE}")"
+fi
+if [ ! -d $(dirname "${ROFI_FB_HISTORY_FILE}") ]
+then
+    mkdir -p "$(dirname "${ROFI_FB_HISTORY_FILE}")"
+fi
+
+# Initialize $ROFI_FB_CUR_DIR
+if [ -d "${ROFI_FB_START_DIR}" ]
+then
+    ROFI_FB_CUR_DIR="${ROFI_FB_START_DIR}"
+else
+    ROFI_FB_CUR_DIR="$PWD"
+fi
+
+# Read last location, otherwise we default to $ROFI_FB_START_DIR or $PWD.
+if [ -f "${ROFI_FB_PREV_LOC_FILE}" ]
+then
+    ROFI_FB_CUR_DIR=$(cat "${ROFI_FB_PREV_LOC_FILE}") 
 fi 
 
 # Handle argument.
 if [ -n "$@" ]
 then
-    CUR_DIR="${CUR_DIR}/$@"
+    if [[ "$@" == /* ]]
+    then
+        ROFI_FB_CUR_DIR="$@"
+    else
+        ROFI_FB_CUR_DIR="${ROFI_FB_CUR_DIR}/$@"
+    fi
 fi
 
 # If argument is no directory.
-if [ ! -d "${CUR_DIR}" ]
+if [ ! -d "${ROFI_FB_CUR_DIR}" ]
 then
-    if [ -x "${CUR_DIR}" ]
+    if [ -x "${ROFI_FB_CUR_DIR}" ]
     then
-        coproc ( "${CUR_DIR}" &  > /dev/null 2>&1 )
+        coproc ( "${ROFI_FB_CUR_DIR}" &  > /dev/null 2>&1 )
         exec 1>&-
         exit;
-    elif [ -f "${CUR_DIR}" ]
+    elif [ -f "${ROFI_FB_CUR_DIR}" ]
     then
-        coproc ( ${EDITOR} "${CUR_DIR}" & > /dev/null  2>&1 )
+        if [[ "${ROFI_FB_NO_HISTORY}" -ne 1 ]]
+        then
+            # Append selected entry to history and remove exceeding entries
+            sed -i "s|${ROFI_FB_CUR_DIR}|##deleted##|g" "${ROFI_FB_HISTORY_FILE}"
+            sed -i '/##deleted##/d' "${ROFI_FB_HISTORY_FILE}"
+            echo "${ROFI_FB_CUR_DIR}" >> "${ROFI_FB_HISTORY_FILE}"
+            if [ $(cat "${ROFI_FB_HISTORY_FILE}" | wc -l) -gt ${ROFI_FB_HISTORY_MAXCOUNT} ]
+            then
+                sed -i 1d "${ROFI_FB_HISTORY_FILE}"
+            fi
+        fi
+        # Open the selected entry with $ROFI_FB_GENERIC_FO
+        coproc ( "${ROFI_FB_GENERIC_FO}" "${ROFI_FB_CUR_DIR}" & > /dev/null  2>&1 )
+        if [ -d "${ROFI_FB_START_DIR}" ]
+        then
+            echo "${ROFI_FB_START_DIR}" > "${ROFI_FB_PREV_LOC_FILE}"
+        fi
         exit;
     fi
     exit;
 fi
 
-# process current dir.
-if [ -n "${CUR_DIR}" ]
+# Process current dir.
+if [ -n "${ROFI_FB_CUR_DIR}" ]
 then
-    CUR_DIR=$(readlink -e "${CUR_DIR}")
-    echo "${CUR_DIR}" > "${PREV_LOC_FILE}"
-    pushd "${CUR_DIR}" >/dev/null
+    ROFI_FB_CUR_DIR=$(readlink -e "${ROFI_FB_CUR_DIR}")
+    echo "${ROFI_FB_CUR_DIR}" > "${ROFI_FB_PREV_LOC_FILE}"
+    pushd "${ROFI_FB_CUR_DIR}" >/dev/null
 fi
 
+# Output to rofi
+if [[ "${ROFI_FB_NO_HISTORY}" -ne 1 ]]
+then
+    tac "${ROFI_FB_HISTORY_FILE}" | grep "${ROFI_FB_CUR_DIR}"
+fi
 echo ".."
 ls
+# vim:sw=4:ts=4:et:


### PR DESCRIPTION
I added the option to enable history in file browser mode. I changed the starting directory to a fixed directory. I found the old behavior not very intuitiv especially with enabled history. The old behavior can be restored easily. Additionally, I changed the variable names. Primarily, because the EDITOR variable could lead to a recursive call to EDITOR if xdg-open used this variable. Thus, I prefixed all the variables to create a new namespace for rofi. I am at most decent in bash scripting so don't expect to much, but it works for me and I thought it might be something others appreciate. I  hope it is of any use. :)