### PR TITLE
Add staleness note to INSTALL.md git instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,6 +62,11 @@ make install
 
 ## Install a checkout from git
 
+The GitHub Pages version of these directions may be out of date.  Please use
+[INSTALL.md from the online repo][master-install] or your local repository.
+
+[master-install]: https://github.com/DaveDavenport/rofi/blob/master/INSTALL.md#install-a-checkout-from-git
+
 Pull in dependencies
 
 ```


### PR DESCRIPTION
Followup to #365 (and #350).  I didn't realize the `gh-pages` version of the instructions tracked the stable release.  It would be nice to know that the "Install a checkout from git" section on the site may be out of date.

Preview available at [the GitHub Pages version on my fork](https://benizi.github.io/rofi/p08-INSTALL.html#install-a-checkout-from-git) (only updated w/ this change, not the entire INSTALL.md).