### PR TITLE
Invalid UTF-8 in window titles crashes switcher. (Fix included)

### DIFF
--- a/source/helper.c
+++ b/source/helper.c
@@ -148,6 +148,15 @@ char *token_collate_key ( const char *token, int case_sensitive )
     }
 
     compk = g_utf8_normalize ( tmp, -1, G_NORMALIZE_ALL );
+
+    // g_utf8_normalize may have failed; in that case, return the unnormalized string
+    if ( compk == NULL ) {
+        compk = tmp;
+    }
+    else {
+        g_free ( tmp );
+    }
+
     g_free ( tmp );
 
     return compk;

--- a/source/helper.c
+++ b/source/helper.c
@@ -157,8 +157,6 @@ char *token_collate_key ( const char *token, int case_sensitive )
         g_free ( tmp );
     }
 
-    g_free ( tmp );
-
     return compk;
 }
 void tokenize_free ( char ** tokens )


### PR DESCRIPTION
It appears that my music player echoes invalid UTF-8 from song titles in its title bar uncritically. This causes rofi's window switching function to segfault in strstr, as the invocation of `g_utf8_normalize` in `token_collate_key` returns NULL in that case and `normal_token_match` goes on to compare against it, apparently assuming it to be a valid pointer.

I've included one possible fix that did the trick for me, but you may prefer to fall back in some other way, try to strip bad UTF-8 altogether or validate the output of `token_collate_key` in all instances.