### PR TITLE
Added the descriptions of the key bindings

### DIFF
--- a/source/keyb.c
+++ b/source/keyb.c
@@ -34,57 +34,159 @@ ActionBindingEntry abe[NUM_ABE];
  */
 DefaultBinding bindings[NUM_ABE] =
 {
-    { .id = PASTE_PRIMARY,           .name = "kb-primary-paste",           .keybinding = "Control+Shift+v,Shift+Insert",              .comment = "Keybinding paste primary clipboard"   },
-    { .id = PASTE_SECONDARY,         .name = "kb-secondary-paste",         .keybinding = "Control+v,Insert",                          .comment = "Keybinding paste secondary clipboard" },
-    { .id = CLEAR_LINE,              .name = "kb-clear-line",              .keybinding = "Control+u",                                 .comment = "Keybinding clear input line"          },
-    { .id = MOVE_FRONT,              .name = "kb-move-front",              .keybinding = "Control+a",                                 .comment = "Keybinding move cursor to front"      },
-    { .id = MOVE_END,                .name = "kb-move-end",                .keybinding = "Control+e",                                 .comment = "Keybinding move cursor to end"        },
-    { .id = MOVE_WORD_BACK,          .name = "kb-move-word-back",          .keybinding = "Alt+b",                                     .comment = "Keybinding move word back"            },
-    { .id = MOVE_WORD_FORWARD,       .name = "kb-move-word-forward",       .keybinding = "Alt+f",                                     .comment = "Keybinding"                           },
-    { .id = MOVE_CHAR_BACK,          .name = "kb-move-char-back",          .keybinding = "Left,Control+b",                            .comment = "Keybinding"                           },
-    { .id = MOVE_CHAR_FORWARD,       .name = "kb-move-char-forward",       .keybinding = "Right,Control+f",                           .comment = "Keybinding"                           },
-    { .id = REMOVE_WORD_BACK,        .name = "kb-remove-word-back",        .keybinding = "Control+Alt+h",                             .comment = "Keybinding"                           },
-    { .id = REMOVE_WORD_FORWARD,     .name = "kb-remove-word-forward",     .keybinding = "Control+Alt+d",                             .comment = "Keybinding"                           },
-    { .id = REMOVE_CHAR_FORWARD,     .name = "kb-remove-char-forward",     .keybinding = "Delete,Control+d",                          .comment = "Keybinding"                           },
-    { .id = REMOVE_CHAR_BACK,        .name = "kb-remove-char-back",        .keybinding = "BackSpace,Control+h",                       .comment = "Keybinding"                           },
-    { .id = ACCEPT_ENTRY,            .name = "kb-accept-entry",            .keybinding = "Control+j,Control+m,Return,KP_Enter",       .comment = "Keybinding"                           },
-    { .id = ACCEPT_CUSTOM,           .name = "kb-accept-custom",           .keybinding = "Control+Return,Shift+Return",               .comment = "Keybinding"                           },
-    { .id = MODE_NEXT,               .name = "kb-mode-next",               .keybinding = "Shift+Right,Control+Tab",                   .comment = "Keybinding"                           },
-    { .id = MODE_PREVIOUS,           .name = "kb-mode-previous",           .keybinding = "Shift+Left,Control+Shift+Tab",              .comment = "Keybinding"                           },
-    { .id = TOGGLE_CASE_SENSITIVITY, .name = "kb-toggle-case-sensitivity", .keybinding = "grave,dead_grave",                          .comment = "Keybinding"                           },
-    { .id = DELETE_ENTRY,            .name = "kb-delete-entry",            .keybinding = "Shift+Delete",                              .comment = "Keybinding"                           },
-    { .id = ROW_LEFT,                .name = "kb-row-left",                .keybinding = "Control+Page_Up",                           .comment = "Keybinding"                           },
-    { .id = ROW_RIGHT,               .name = "kb-row-right",               .keybinding = "Control+Page_Down",                         .comment = "Keybinding"                           },
-    { .id = ROW_UP,                  .name = "kb-row-up",                  .keybinding = "Up,Control+p,Shift+Tab,Shift+ISO_Left_Tab", .comment = "Keybinding"                           },
-    { .id = ROW_DOWN,                .name = "kb-row-down",                .keybinding = "Down,Control+n",                            .comment = "Keybinding"                           },
-    { .id = ROW_TAB,                 .name = "kb-row-tab",                 .keybinding = "Tab",                                       .comment = "Keybinding"                           },
-    { .id = PAGE_PREV,               .name = "kb-page-prev",               .keybinding = "Page_Up",                                   .comment = "Keybinding"                           },
-    { .id = PAGE_NEXT,               .name = "kb-page-next",               .keybinding = "Page_Down",                                 .comment = "Keybinding"                           },
-    { .id = ROW_FIRST,               .name = "kb-row-first",               .keybinding = "Home,KP_Home",                              .comment = "Keybinding"                           },
-    { .id = ROW_LAST,                .name = "kb-row-last",                .keybinding = "End,KP_End",                                .comment = "Keybinding"                           },
-    { .id = ROW_SELECT,              .name = "kb-row-select",              .keybinding = "Control+space",                             .comment = "Keybinding"                           },
-    { .id = CANCEL,                  .name = "kb-cancel",                  .keybinding = "Escape,Control+bracketleft",                .comment = "Keybinding"                           },
-    { .id = CUSTOM_1,                .name = "kb-custom-1",                .keybinding = "Alt+1",                                     .comment = "Keybinding"                           },
-    { .id = CUSTOM_2,                .name = "kb-custom-2",                .keybinding = "Alt+2",                                     .comment = "Keybinding"                           },
-    { .id = CUSTOM_3,                .name = "kb-custom-3",                .keybinding = "Alt+3",                                     .comment = "Keybinding"                           },
-    { .id = CUSTOM_4,                .name = "kb-custom-4",                .keybinding = "Alt+4",                                     .comment = "Keybinding"                           },
-    { .id = CUSTOM_5,                .name = "kb-custom-5",                .keybinding = "Alt+5",                                     .comment = "Keybinding"                           },
-    { .id = CUSTOM_6,                .name = "kb-custom-6",                .keybinding = "Alt+6",                                     .comment = "Keybinding"                           },
-    { .id = CUSTOM_7,                .name = "kb-custom-7",                .keybinding = "Alt+7",                                     .comment = "Keybinding"                           },
-    { .id = CUSTOM_8,                .name = "kb-custom-8",                .keybinding = "Alt+8",                                     .comment = "Keybinding"                           },
-    { .id = CUSTOM_9,                .name = "kb-custom-9",                .keybinding = "Alt+9",                                     .comment = "Keybinding"                           },
-    { .id = CUSTOM_10,               .name = "kb-custom-10",               .keybinding = "Alt+0",                                     .comment = "Keybinding"                           },
-    { .id = CUSTOM_11,               .name = "kb-custom-11",               .keybinding = "Alt+Shift+1",                               .comment = "Keybinding"                           },
-    { .id = CUSTOM_12,               .name = "kb-custom-12",               .keybinding = "Alt+Shift+2",                               .comment = "Keybinding"                           },
-    { .id = CUSTOM_13,               .name = "kb-custom-13",               .keybinding = "Alt+Shift+3",                               .comment = "Keybinding"                           },
-    { .id = CUSTOM_14,               .name = "kb-custom-14",               .keybinding = "Alt+Shift+4",                               .comment = "Keybinding"                           },
-    { .id = CUSTOM_15,               .name = "kb-custom-15",               .keybinding = "Alt+Shift+5",                               .comment = "Keybinding"                           },
-    { .id = CUSTOM_16,               .name = "kb-custom-16",               .keybinding = "Alt+Shift+6",                               .comment = "Keybinding"                           },
-    { .id = CUSTOM_18,               .name = "kb-custom-18",               .keybinding = "Alt+Shift+8",                               .comment = "Keybinding"                           },
-    { .id = CUSTOM_17,               .name = "kb-custom-17",               .keybinding = "Alt+Shift+7",                               .comment = "Keybinding"                           },
-    { .id = CUSTOM_19,               .name = "kb-custom-19",               .keybinding = "Alt+Shift+9",                               .comment = "Keybinding"                           },
-    { .id = SCREENSHOT,              .name = "kb-screenshot",              .keybinding = "Alt+Shift+S",                               .comment = "Keybinding"                           },
-    { .id = TOGGLE_SORT,             .name = "kb-toggle-sort",             .keybinding = "Alt+grave",                                 .comment = "Keybinding"                           },
+    { .id = PASTE_PRIMARY,           .name = "kb-primary-paste",                            .keybinding = "Control+Shift+v,Shift+Insert",              
+      .comment = "Paste primary selection"                                            },
+
+    { .id = PASTE_SECONDARY,         .name = "kb-secondary-paste",                          .keybinding = "Control+v,Insert",                          
+      .comment = "Paste clipboard"                                                    },
+    
+    { .id = CLEAR_LINE,              .name = "kb-clear-line",                               .keybinding = "Control+u",                                 
+      .comment = "Clear input line"                                                   },
+    
+    { .id = MOVE_FRONT,              .name = "kb-move-front",                               .keybinding = "Control+a",                                 
+      .comment = "Beginning of line"                                                  },
+    
+    { .id = MOVE_END,                .name = "kb-move-end",                                 .keybinding = "Control+e",                                 
+      .comment = "End of line"                                                        },
+    
+    { .id = MOVE_WORD_BACK,          .name = "kb-move-word-back",                           .keybinding = "Alt+b",                                     
+      .comment = "Move back one word"                                                 },
+
+    { .id = MOVE_WORD_FORWARD,       .name = "kb-move-word-forward",                        .keybinding = "Alt+f",                                     
+      .comment = "Move forward one word"                                              },
+
+    { .id = MOVE_CHAR_BACK,          .name = "kb-move-char-back",                           .keybinding = "Left,Control+b",                            
+      .comment = "Move back one char"                                                 },
+    
+    { .id = MOVE_CHAR_FORWARD,       .name = "kb-move-char-forward",                        .keybinding = "Right,Control+f",                           
+      .comment = "Move forward one char"                                              },
+
+    { .id = REMOVE_WORD_BACK,        .name = "kb-remove-word-back",                         .keybinding = "Control+Alt+h",                             
+      .comment = "Delete previous word"                                               },
+
+    { .id = REMOVE_WORD_FORWARD,     .name = "kb-remove-word-forward",                      .keybinding = "Control+Alt+d",                             
+      .comment = "Delete next word"                                                   },
+
+    { .id = REMOVE_CHAR_FORWARD,     .name = "kb-remove-char-forward",                      .keybinding = "Delete,Control+d",                          
+      .comment = "Delete next char"                                                   },
+
+    { .id = REMOVE_CHAR_BACK,        .name = "kb-remove-char-back",                         .keybinding = "BackSpace,Control+h",                       
+      .comment = "Delete previous char"                                               },
+
+    { .id = ACCEPT_ENTRY,            .name = "kb-accept-entry",                             .keybinding = "Control+j,Control+m,Return,KP_Enter",       
+      .comment = "Accept entry"                                                       },
+
+    { .id = ACCEPT_CUSTOM,           .name = "kb-accept-custom",                            .keybinding = "Control+Return,Shift+Return",               
+      .comment = "Use entered text as command (in ssh/run modi)"                      },
+
+    { .id = DELETE_ENTRY,            .name = "kb-delete-entry",                             .keybinding = "Shift+Delete",                              
+      .comment = "Delete entry from history"                                          },
+
+    { .id = MODE_NEXT,               .name = "kb-mode-next",                                .keybinding = "Shift+Right,Control+Tab",                   
+      .comment = "Switch to the next modi. Add/remove modis with -switchers"          },
+
+    { .id = MODE_PREVIOUS,           .name = "kb-mode-previous",                            .keybinding = "Shift+Left,Control+Shift+Tab",              
+      .comment = "Switch to the previous modi. Add/remove modis with -switchers"      },
+
+    { .id = ROW_LEFT,                .name = "kb-row-left",                                 .keybinding = "Control+Page_Up",                           
+      .comment = "Go to the previous column"                                          },
+
+    { .id = ROW_RIGHT,               .name = "kb-row-right",                                .keybinding = "Control+Page_Down",                         
+      .comment = "Go to the next column"                                              },
+
+    { .id = ROW_UP,                  .name = "kb-row-up",                                   .keybinding = "Up,Control+p,Shift+Tab,Shift+ISO_Left_Tab", 
+      .comment = "Select previous entry"                                              },
+
+    { .id = ROW_DOWN,                .name = "kb-row-down",                                 .keybinding = "Down,Control+n,Tab",                            
+      .comment = "Select next entry"                                                  },
+    
+    { .id = ROW_TAB,                 .name = "kb-row-tab",                                  .keybinding = "Tab",                                       
+      .comment = "Tab"                                                                },
+
+    { .id = PAGE_PREV,               .name = "kb-page-prev",                                .keybinding = "Page_Up",                                   
+      .comment = "Go to the previous page"                                            },
+
+    { .id = PAGE_NEXT,               .name = "kb-page-next",                                .keybinding = "Page_Down",                                 
+      .comment = "Go to the next page"                                                },
+
+    { .id = ROW_FIRST,               .name = "kb-row-first",                                .keybinding = "Home,KP_Home",                              
+      .comment = "Go to the first entry"                                              },
+
+    { .id = ROW_LAST,                .name = "kb-row-last",                                 .keybinding = "End,KP_End",                                
+      .comment = "Go to the last entry"                                               },
+
+    { .id = ROW_SELECT,              .name = "kb-row-select",                               .keybinding = "Control+space",                             
+      .comment = "Set selected item as input text"                                    },
+
+    { .id = SCREENSHOT,              .name = "kb-screenshot",                               .keybinding = "Alt+Shift+S",                               
+      .comment = "Take a screenshot of the rofi window"                               },
+
+    { .id = TOGGLE_CASE_SENSITIVITY, .name = "kb-toggle-case-sensitivity",                  .keybinding = "grave,dead_grave",                          
+      .comment = "Toggle case sensitivity"                                            },
+
+    { .id = TOGGLE_SORT,             .name = "kb-toggle-sort",                              .keybinding = "Alt+grave",                                 
+      .comment = "Toggle sort"                                                        },
+
+    { .id = CANCEL,                  .name = "kb-cancel",                                   .keybinding = "Escape,Control+bracketleft",                
+      .comment = "Quit rofi"                                                          },
+
+    { .id = CUSTOM_1,                .name = "kb-custom-1",                                 .keybinding = "Alt+1",                                     
+      .comment = "Custom keybinding 1"                                                },
+
+    { .id = CUSTOM_2,                .name = "kb-custom-2",                                 .keybinding = "Alt+2",                                     
+      .comment = "Custom keybinding 2"                                                },
+
+    { .id = CUSTOM_3,                .name = "kb-custom-3",                                 .keybinding = "Alt+3",                                     
+      .comment = "Custom keybinding 3"                                                },
+
+    { .id = CUSTOM_4,                .name = "kb-custom-4",                                 .keybinding = "Alt+4",                                     
+      .comment = "Custom keybinding 4"                                                },
+
+    { .id = CUSTOM_5,                .name = "kb-custom-5",                                 .keybinding = "Alt+5",                                     
+      .comment = "Custom Keybinding 5"                                                },
+
+    { .id = CUSTOM_6,                .name = "kb-custom-6",                                 .keybinding = "Alt+6",                                     
+      .comment = "Custom keybinding 6"                                                },
+
+    { .id = CUSTOM_7,                .name = "kb-custom-7",                                 .keybinding = "Alt+7",                                     
+      .comment = "Custom Keybinding 7"                                                },
+
+    { .id = CUSTOM_8,                .name = "kb-custom-8",                                 .keybinding = "Alt+8",                                     
+      .comment = "Custom keybinding 8"                                                },
+
+    { .id = CUSTOM_9,                .name = "kb-custom-9",                                 .keybinding = "Alt+9",                                     
+      .comment = "Custom keybinding 9"                                                },
+
+    { .id = CUSTOM_10,               .name = "kb-custom-10",                                .keybinding = "Alt+0",                                     
+      .comment = "Custom keybinding 10"                                               },
+    
+    { .id = CUSTOM_11,               .name = "kb-custom-11",                                .keybinding = "Alt+Shift+1",                               
+      .comment = "Custom keybinding 11"                                               },
+    
+    { .id = CUSTOM_12,               .name = "kb-custom-12",                                .keybinding = "Alt+Shift+2",                               
+      .comment = "Custom keybinding 12"                                               },
+
+    { .id = CUSTOM_13,               .name = "kb-custom-13",                                .keybinding = "Alt+Shift+3",                               
+      .comment = "Csutom keybinding 13"                                               },
+
+    { .id = CUSTOM_14,               .name = "kb-custom-14",                                .keybinding = "Alt+Shift+4",                               
+      .comment = "Custom keybinding 14"                                               },
+
+    { .id = CUSTOM_15,               .name = "kb-custom-15",                                .keybinding = "Alt+Shift+5",                               
+      .comment = "Custom keybinding 15"                                               },
+
+    { .id = CUSTOM_16,               .name = "kb-custom-16",                                .keybinding = "Alt+Shift+6",                               
+      .comment = "Custom keybinding 16"                                               },
+
+    { .id = CUSTOM_17,               .name = "kb-custom-17",                                .keybinding = "Alt+Shift+7",                               
+      .comment = "Custom keybinding 17"                                               },
+
+    { .id = CUSTOM_18,               .name = "kb-custom-18",                                .keybinding = "Alt+Shift+8",                               
+      .comment = "Custom keybinding 18"                                               },
+
+    { .id = CUSTOM_19,               .name = "kb-custom-19",                                .keybinding = "Alt+Shift+9",                               
+      .comment = "Custom Keybinding 19"                                               },
+
 };
 
 void setup_abe ( void )

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -608,8 +608,8 @@ static char * config_parser_return_display_help_entry ( XrmOption *option )
         return g_markup_printf_escaped ( "<b%s</b> (%d) <span style='italic' size='small'>%s</span>",
                                          option->name, *( option->value.snum ), option->comment );
     case xrm_String:
-        return g_markup_printf_escaped ( "<b>%s</b> (%s) <span style='italic' size='small'>%s</span>",
-                                         option->name,
+        return g_markup_printf_escaped ( "<b>%s</b> <span style='italic' size='small'>%s</span>",
+                                         //option->name,
                                          ( *( option->value.str ) != NULL ) ? *( option->value.str ) : "null",
                                          option->comment
                                          );


### PR DESCRIPTION
I reformatted the entries for the key bindings so that I could have the vim window with the rofi source and the window with the manual open side by side.

I could not understand from the code what other uses does the Tab key have.

I think it would be nice to use a [macro](https://github.com/eudoxia0/cmacro) to generate the code for the custom keybindings.

I think the current output format is clearer than the previous one.

Feel free to modify anything.