### PR TITLE
Wip/drun subdirs

### DIFF
--- a/source/dialogs/drun.c
+++ b/source/dialogs/drun.c
@@ -208,8 +208,8 @@ static void walk_dir ( DRunModePrivateData *pd, const char *dirname )
     }
 
     struct dirent *file;
-    gchar       *filename = NULL;
-    struct stat st;
+    gchar         *filename = NULL;
+    struct stat   st;
     while ( ( file = readdir ( dir ) ) != NULL ) {
         if ( file->d_name[0] == '.' ) {
             continue;
@@ -222,21 +222,20 @@ static void walk_dir ( DRunModePrivateData *pd, const char *dirname )
         case DT_DIR:
         case DT_UKNOWN:
             filename = g_build_filename ( dirname, file->d_name, NULL );
-        break;
+            break;
         default:
             continue;
         }
 
         // On a link, or if FS does not support providing this information
         // Fallback to stat method.
-        if ( file->d_type == DT_LNK || file->d_type == DT_UNKNOWN )
-        {
+        if ( file->d_type == DT_LNK || file->d_type == DT_UNKNOWN ) {
             file->d_type = DT_UNKNOWN;
-            if ( stat(filename, &st) == 0 ) {
-                if ( S_ISDIR(st.st_mode) ) {
+            if ( stat ( filename, &st ) == 0 ) {
+                if ( S_ISDIR ( st.st_mode ) ) {
                     file->d_type = DT_DIR;
                 }
-                else if ( S_ISREG(st.st_mode) ) {
+                else if ( S_ISREG ( st.st_mode ) ) {
                     file->d_type = DT_REG;
                 }
             }
@@ -247,10 +246,10 @@ static void walk_dir ( DRunModePrivateData *pd, const char *dirname )
         case DT_REG:
             read_desktop_file ( pd, filename, file->d_name );
             filename = NULL;
-        break;
+            break;
         case DT_DIR:
             walk_dir ( pd, filename );
-        break;
+            break;
         default:
             break;
         }

--- a/source/dialogs/drun.c
+++ b/source/dialogs/drun.c
@@ -215,6 +215,18 @@ static void walk_dir ( DRunModePrivateData *pd, const char *dirname )
             continue;
         }
 
+        switch ( file->d_type )
+        {
+        case DT_LNK:
+        case DT_REG:
+        case DT_DIR:
+        case DT_UKNOWN:
+            filename = g_build_filename ( dirname, file->d_name, NULL );
+        break;
+        default:
+            continue;
+        }
+
         // On a link, or if FS does not support providing this information
         // Fallback to stat method.
         if ( file->d_type == DT_LNK || file->d_type == DT_UNKNOWN )
@@ -232,17 +244,6 @@ static void walk_dir ( DRunModePrivateData *pd, const char *dirname )
 
         switch ( file->d_type )
         {
-        case DT_LNK:
-        case DT_REG:
-        case DT_DIR:
-            filename = g_build_filename ( dirname, file->d_name, NULL );
-        break;
-        default:
-            continue;
-        }
-
-        switch ( file->d_type )
-        {
         case DT_REG:
             read_desktop_file ( pd, filename, file->d_name );
             filename = NULL;
@@ -250,6 +251,8 @@ static void walk_dir ( DRunModePrivateData *pd, const char *dirname )
         case DT_DIR:
             walk_dir ( pd, filename );
         break;
+        default:
+            break;
         }
         g_free ( filename );
     }

--- a/source/dialogs/drun.c
+++ b/source/dialogs/drun.c
@@ -220,7 +220,7 @@ static void walk_dir ( DRunModePrivateData *pd, const char *dirname )
         case DT_LNK:
         case DT_REG:
         case DT_DIR:
-        case DT_UKNOWN:
+        case DT_UNKNOWN:
             filename = g_build_filename ( dirname, file->d_name, NULL );
             break;
         default:


### PR DESCRIPTION
Make the desktop file based run dialog recursively go down the directories.
Fix following  symlinks and filesystems that do not report file type. (see man readdir)