### PR TITLE
Use bash instead of sh for get_git_rev.sh

### DIFF
--- a/script/get_git_rev.sh
+++ b/script/get_git_rev.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 DIR=$1
 FILE=$2


### PR DESCRIPTION
The script relies on bash extensions to `echo`, which is not portable to
POSIX shells. Simplest fix is to request bash explicitly.