### PR TITLE
add xinerama support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,7 +94,7 @@ dnl ---------------------------------------------------------------------
 dnl PKG_CONFIG based dependencies  
 dnl ---------------------------------------------------------------------
 PKG_CHECK_MODULES([glib],     [glib-2.0 >= 2.40])
-GW_CHECK_XCB([xcb-aux xcb-xkb xkbcommon >= 0.5.0 xkbcommon-x11 xcb-ewmh xcb-icccm xcb-xrm xcb-randr])
+GW_CHECK_XCB([xcb-aux xcb-xkb xkbcommon >= 0.5.0 xkbcommon-x11 xcb-ewmh xcb-icccm xcb-xrm xcb-randr xcb-xinerama])
 PKG_CHECK_MODULES([pango],    [pango pangocairo])
 PKG_CHECK_MODULES([cairo],	  [cairo cairo-xcb])
 PKG_CHECK_MODULES([libsn],    [libstartup-notification-1.0])

--- a/include/x11-helper.h
+++ b/include/x11-helper.h
@@ -153,6 +153,8 @@ cairo_surface_t * x11_helper_get_bg_surface ( void );
  * Creates an internal represenation of the available monitors.
  * Used for positioning rofi.
  */
+uint8_t x11_is_randr_present ( void );
+void x11_build_monitor_layout_xinerama ( void );
 void x11_build_monitor_layout ( void );
 void x11_dump_monitor_layout ( void );
 /*@}*/

--- a/include/x11-helper.h
+++ b/include/x11-helper.h
@@ -153,8 +153,6 @@ cairo_surface_t * x11_helper_get_bg_surface ( void );
  * Creates an internal represenation of the available monitors.
  * Used for positioning rofi.
  */
-uint8_t x11_is_randr_present ( void );
-void x11_build_monitor_layout_xinerama ( void );
 void x11_build_monitor_layout ( void );
 void x11_dump_monitor_layout ( void );
 /*@}*/

--- a/source/x11-helper.c
+++ b/source/x11-helper.c
@@ -56,6 +56,9 @@
 #include "x11-helper.h"
 #include "xkb-internal.h"
 
+int x11_is_randr_present ( void );
+void x11_build_monitor_layout_xinerama ( void );
+
 struct _xcb_stuff xcb_int = {
     .connection = NULL,
     .screen     = NULL,
@@ -215,7 +218,7 @@ static workarea * x11_get_monitor_from_output ( xcb_randr_output_t out )
     return retv;
 }
 
-uint8_t x11_is_randr_present () {
+int x11_is_randr_present () {
     xcb_query_extension_cookie_t randr_cookie = xcb_query_extension (
         xcb->connection,
         sizeof("RANDR")-1,
@@ -228,7 +231,15 @@ uint8_t x11_is_randr_present () {
         NULL
     );
 
-    return randr_reply->present;
+    uint8_t present = randr_reply->present;
+
+    free ( randr_reply );
+
+    if ( present ) {
+        return TRUE;
+    } else {
+        return FALSE;
+    }
 }
 
 void x11_build_monitor_layout_xinerama () {


### PR DESCRIPTION
My Xorg setup doesn't support RANDR (nvidia+xorg), so I basically get error
when trying to run `rofi`. It's because `rofi` requests `randr` info and
break xcb connection by doing that.

```
xkbcommon: ERROR: xkb_x11_keymap_new_from_device: illegal device ID: -1
Failed to get Keymap for current keyboard device.
*** Error in `rofi': double free or corruption (top): 0x000000000098f7c0 ***
```