### PR TITLE
man: Typo fix

### DIFF
--- a/doc/rofi-manpage.markdown
+++ b/doc/rofi-manpage.markdown
@@ -176,7 +176,7 @@ Custom modes can be added using the internal 'script' mode. Each mode has two pa
 
 Example: Have a mode 'Workspaces' using the `i3_switch_workspace.sh` script:
 
-    rofi -modi "window,run,ssh,Workspaces:i3_switch_workspaces.sh" -show Workspaces
+    rofi -modi "window,run,ssh,Workspaces:i3_switch_workspace.sh" -show Workspaces
 
 `-case-sensitive`
 


### PR DESCRIPTION
Just a tiny typo fix for the -modi docs.