### PR TITLE
changed subprocess call in file-browser example

### DIFF
--- a/Examples/rofi-file-browser.sh
+++ b/Examples/rofi-file-browser.sh
@@ -70,7 +70,7 @@ then
             fi
         fi
         # Open the selected entry with $ROFI_FB_GENERIC_FO
-        coproc ( "${ROFI_FB_GENERIC_FO}" "${ROFI_FB_CUR_DIR}" & > /dev/null  2>&1 )
+        coproc ( "${ROFI_FB_GENERIC_FO}" "${ROFI_FB_CUR_DIR}" > /dev/null  2>&1 )
         if [ -d "${ROFI_FB_START_DIR}" ]
         then
             echo "${ROFI_FB_START_DIR}" > "${ROFI_FB_PREV_LOC_FILE}"


### PR DESCRIPTION
Hi, this is a really tiny thing but it's been bothering for a while:
I'm using the file-browser script as a quick way to open files, but xdg-open always seemed to open the wrong programs (mostly firefox, but for everything).
After spending way too much time on this, I traced it to the "coproc" call. When used in a bash shell, it works normally, but called from a script it seems to mess with the way xdg-open opens files.
Anyways, removing the first ampersand from that line fixes it.
From the bash manpage: 
```
There are two formats for redirecting standard output and standard error:

              &>word
       and
              >&word

Of the two forms, the first is preferred.  This is semantically equivalent to

              >word 2>&1
```
So to me, it seems either the first ampersand or 2nd redirect is superfluous.

Just one character, but this has itched me for some time now and maybe it helps someone else.