### PR TITLE
Input location should be configurable

### DIFF
--- a/config/config.c
+++ b/config/config.c
@@ -76,6 +76,14 @@ Settings config = {
      *
      */
     .location          = WL_CENTER,
+    /**
+     * Location of the input line.
+     * Enumeration indicating location of the input line
+     *
+     * IL_TOP       IL_BOTTOM
+     *
+     */
+    .input_location          = IL_TOP,
     /** Padding between elements */
     .padding           =                                         5,
     /** Y offset */

--- a/doc/rofi-manpage.markdown
+++ b/doc/rofi-manpage.markdown
@@ -13,6 +13,7 @@
 [ -font *pangofont* ]
 [ -terminal *terminal* ]
 [ -location *position* ]
+[ -input-location *position* ]
 [ -fixed-num-lines ]
 [ -padding *padding* ]
 [ -display *display* ]
@@ -234,7 +235,7 @@ Default: *1*
 
 The following options are further explained in the theming section:
 
-`-color-window` *background* *border color* *separator color* 
+`-color-window` *background* *border color* *separator color*
 
 Set window background, border and separator color.
 
@@ -329,6 +330,19 @@ Specify where the window should be located. The numbers map to the following loc
       1 2 3
       8 0 4
       7 6 5
+
+Default: *0*
+
+`-input-location`
+
+Specify where the input line should be placed, regarding the results (0
+above the results, while 1 will place it bellow):
+
+      input-location 0
+      -----
+      results
+      -----
+      input-location 1
 
 Default: *0*
 

--- a/include/settings.h
+++ b/include/settings.h
@@ -48,6 +48,21 @@ typedef enum
 } WindowLocation;
 
 /**
+ * Enumeration indicating location of the input line
+ *
+ * \verbatim IL_TOP      IL_BOTTOM \endverbatim
+ *
+ * @ingroup CONFIGURATION
+ */
+typedef enum
+{
+    /** Above proposals */
+    IL_TOP    = 0,
+    /** Bellow proposals */
+    IL_BOTTOM = 1
+} InputLocation;
+
+/**
  * Settings structure holding all (static) configurable options.
  * @ingroup CONFIGURATION
  */
@@ -88,6 +103,8 @@ typedef struct
 
     /** Windows location/gravity */
     WindowLocation location;
+    /** Input line location */
+    InputLocation input_location;
     /** Padding between elements */
     unsigned int   padding;
     /** Y offset */

--- a/source/view.c
+++ b/source/view.c
@@ -1459,21 +1459,14 @@ RofiViewState *rofi_view_create ( Mode *sw,
 
     int end = ( config.location == WL_EAST_SOUTH || config.location == WL_SOUTH || config.location == WL_SOUTH_WEST );
 
-    fprintf ( stderr, "config input location: %d\n", config.input_location );
-    fprintf ( stderr, "end value before: %d\n", end );
-
     if ( end == TRUE && config.input_location == IL_TOP ) {
       // Rofi run in top locations but we want the input line bellow proposals
-      fprintf ( stderr, "modifying to false" );
       end = FALSE;
 
     } else if ( end == FALSE && config.input_location == IL_BOTTOM ) {
       // Rofi run in bottom locations but we want the input line above proposals
-      fprintf ( stderr, "modifying to true" );
       end = TRUE;
     }
-
-    fprintf ( stderr, "end value after: %d\n", end );
 
     box_add ( state->main_box, WIDGET ( state->input_bar ), FALSE, end );
 

--- a/source/view.c
+++ b/source/view.c
@@ -1458,6 +1458,23 @@ RofiViewState *rofi_view_create ( Mode *sw,
     }
 
     int end = ( config.location == WL_EAST_SOUTH || config.location == WL_SOUTH || config.location == WL_SOUTH_WEST );
+
+    fprintf ( stderr, "config input location: %d\n", config.input_location );
+    fprintf ( stderr, "end value before: %d\n", end );
+
+    if ( end == TRUE && config.input_location == IL_TOP ) {
+      // Rofi run in top locations but we want the input line bellow proposals
+      fprintf ( stderr, "modifying to false" );
+      end = FALSE;
+
+    } else if ( end == FALSE && config.input_location == IL_BOTTOM ) {
+      // Rofi run in bottom locations but we want the input line above proposals
+      fprintf ( stderr, "modifying to true" );
+      end = TRUE;
+    }
+
+    fprintf ( stderr, "end value after: %d\n", end );
+
     box_add ( state->main_box, WIDGET ( state->input_bar ), FALSE, end );
 
     state->case_indicator = textbox_create ( TB_AUTOWIDTH, 0, 0, 0, line_height, NORMAL, "*" );

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -111,6 +111,9 @@ static XrmOption xrmOptions[] = {
     { xrm_Number,  "location",          { .num  = &config.location             }, NULL,
       "Location on screen", CONFIG_DEFAULT },
 
+    { xrm_Number,  "input-location",    { .num  = &config.input_location       }, NULL,
+      "Input location", CONFIG_DEFAULT },
+
     { xrm_Number,  "padding",           { .num  = &config.padding              }, NULL,
       "Padding", CONFIG_DEFAULT },
     { xrm_SNumber, "yoffset",           { .snum = &config.y_offset             }, NULL,


### PR DESCRIPTION
One may want to keep input bar above results, even if rofi start at the bottom of the screen, or in the contrary input bar bellow results when rofi run at the top of the screen.