### PR TITLE
Usability enhancements

### DIFF
--- a/source/dialogs/combi.c
+++ b/source/dialogs/combi.c
@@ -237,14 +237,20 @@ static char * combi_preprocess_input ( Mode *sw, const char *input )
 {
     CombiModePrivateData *pd = mode_get_private_data ( sw );
     pd->current = NULL;
-    if ( input != NULL && input[0] == '!' && strlen ( input ) > 1 ) {
-        for ( unsigned i = 0; i < pd->num_switchers; i++ ) {
-            if ( input[1] == mode_get_name ( pd->switchers[i] )[0] ) {
-                pd->current = pd->switchers[i];
-                if ( input[2] == '\0' ) {
-                    return NULL;
+    if ( input != NULL && input[0] == '!' ) {
+        char *eob = strchrnul ( input, ' ' );
+        ssize_t bang_len = eob - input - 1;
+        if ( bang_len > 0 ) {
+            for ( unsigned i = 0; i < pd->num_switchers; i++ ) {
+                const char *mode_name = mode_get_name ( pd->switchers[i] );
+                size_t mode_name_len = strlen ( mode_name );
+                if ( (size_t) bang_len <= mode_name_len && strncmp ( &input[1], mode_name, bang_len ) == 0 ) {
+                    pd->current = pd->switchers[i];
+                    if ( eob[0] == '\0' || eob[1] == '\0' ) {
+                        return NULL;
+                    }
+                    return g_strdup ( eob+1 );
                 }
-                return g_strdup ( &input[2] );
             }
         }
     }

--- a/source/view.c
+++ b/source/view.c
@@ -667,9 +667,14 @@ void __create_window ( MenuFlags menu_flags )
     // Set the font options from the xlib surface
     pango_cairo_context_set_font_options ( p, fo );
     // Setup dpi
-    if ( config.dpi > 0 ) {
+    double dpi = config.dpi;
+    if ( dpi <= 0 ) {
+        // Default to using X11's vertical dpi
+        dpi = (double) xcb->screen->height_in_pixels * 25.4 / (double) xcb->screen->height_in_millimeters;
+    }
+    if ( dpi > 0 ) {
         PangoFontMap *font_map = pango_cairo_font_map_get_default ();
-        pango_cairo_font_map_set_resolution ( (PangoCairoFontMap *) font_map, (double) config.dpi );
+        pango_cairo_font_map_set_resolution ( (PangoCairoFontMap *) font_map, dpi );
     }
     // Setup font.
     // Dummy widget.


### PR DESCRIPTION
#### Bang mode prefixes
This is required to match on modes that share a prefix.
Let 'power' and 'pass' be such modes for the following explanation:
Previously, only the first character after the bang was compared,
so '!p' would always be matched to the 'pass' mode and there was no
way to limit selection in combi mode to the 'power' mode.
Now we can use prefixes of arbitrary length following the bang
such as '!po' (matches 'power' mode), or '!pa' (matches 'pass' mode).
Prefixes of length 1 are unchanged compared to the previous
behaviour, i.e. '!p' will still match 'pass'.

#### Automatic DPI scaling
If no specific dpi is requested match the one of the X11
screen we connected to by default.
This is necessary for out-of-the-box support of HIDPI monitors,
especially when the user - e.g. on a laptop with such
an internal monitor - frequently switches between internal
and external (normal dpi) monitors.