### PR TITLE
Fix build instructions.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -87,22 +87,10 @@ Generate build system:
 autoreconf -i
 ```
 
-Create a build directory:
-
-```
-mkdir build
-```
-
-Enter build directory:
-
-```
-cd build
-```
-
 Check dependencies and configure build system:
 
 ```
-../configure
+./configure
 ```
 
 Build rofi:


### PR DESCRIPTION
After clean checkout I was unable to build rofi following instructions instructions in INSTALL.md
```
~/rofi/build master
❯ make
../script/get_git_rev.sh .. ./gitconfig.h
  YACC     lexer/theme-parser.c
bison: /home/sarg/rofi/build/lexer/theme-parser.y: cannot open: No such file or directory
Makefile:2836: recipe for target 'lexer/theme-parser.c' failed
make: *** [lexer/theme-parser.c] Error 1
```