### PR TITLE
Handle null X events without error.  Plus Dave's Async patch

### DIFF
--- a/include/widgets/textbox.h
+++ b/include/widgets/textbox.h
@@ -39,6 +39,7 @@ typedef struct
     guint            blink_timeout;
 
     PangoFontMetrics *metrics;
+    int              left_offset;
     //
     const char       *theme_name;
 } textbox;
@@ -58,6 +59,7 @@ typedef enum
         TB_WRAP      = 1 << 21,
         TB_PASSWORD  = 1 << 22,
         TB_INDICATOR = 1 << 23,
+        TB_ICON      = 1 << 24,
 } TextboxFlags;
 /**
  * Flags indicating current state of the textbox.

--- a/source/rofi.c
+++ b/source/rofi.c
@@ -662,9 +662,14 @@ static gboolean main_loop_x11_event_handler ( xcb_generic_event_t *ev, G_GNUC_UN
 {
     if ( ev == NULL ) {
         int status = xcb_connection_has_error ( xcb->connection );
-        fprintf ( stderr, "The XCB connection to X server had a fatal error: %d\n", status );
-        g_main_loop_quit ( main_loop );
-        return G_SOURCE_REMOVE;
+        if(status > 0) {
+            fprintf ( stderr, "The XCB connection to X server had a fatal error: %d\n", status );
+            g_main_loop_quit ( main_loop );
+            return G_SOURCE_REMOVE;
+        } else {
+            fprintf ( stderr, "Warning: main_loop_x11_event_handler: ev == NULL, status == %d\n", status );
+            return G_SOURCE_CONTINUE;
+        }
     }
     uint8_t type = ev->response_type & ~0x80;
     if ( type == xkb.first_event ) {

--- a/source/widgets/listview.c
+++ b/source/widgets/listview.c
@@ -240,7 +240,8 @@ static void listview_recompute_elements ( listview *lv )
         char *name = g_strjoin ( ".", lv->listview_name, "element", NULL );
         for ( unsigned int i = lv->cur_elements; i < newne; i++ ) {
             TextboxFlags flags = ( lv->multi_select ) ? TB_INDICATOR : 0;
-            lv->boxes[i] = textbox_create ( name, flags, NORMAL, "" );
+            /*lv->boxes[i] = textbox_create ( name, flags, NORMAL, "" );*/
+            lv->boxes[i] = textbox_create ( name, flags|TB_ICON, NORMAL, "" );
         }
         g_free ( name );
     }


### PR DESCRIPTION
Small patch to ignore NULL X events when xcb_connection_has_error() also reports no error.

I was seeing rofi crash without displaying at all in the wip-icons branch when running with `-dpi 1` or `-dpi 0`  like so:

```
$ G_MESSAGES_DEBUG=all ./rofi  -combi-modi window,drun -show combi -modi combi -dpi 1  > rofi.log                                                                                   
The XCB connection to X server had a fatal error: 0

$ G_MESSAGES_DEBUG=all ./rofi  -combi-modi window,drun -show combi -modi combi -dpi 0  > rofi.log                                                                                   
The XCB connection to X server had a fatal error: 0

```

The docs here suggest that if xcb_connection_has_error() returns 0 if there is no error: https://xcb.freedesktop.org/manual/group__XCB__Core__API.html#ga70a6bade94bd2824db552abcf5fbdbe3 

With this patch applied rofi runs as per normal with the `-dpi 0` or `-dpi 1` arguments.