### PR TITLE
Fix rofi-sensible-terminal for termite.

### DIFF
--- a/script/rofi-sensible-terminal
+++ b/script/rofi-sensible-terminal
@@ -11,7 +11,18 @@
 # symlink for example.
 for terminal in $TERMINAL x-terminal-emulator termite urxvt rxvt st terminator terminology qterminal Eterm aterm uxterm xterm gnome-terminal roxterm xfce4-terminal mate-terminal lxterminal; do
     if command -v $terminal > /dev/null 2>&1; then
-        exec $terminal "$@"
+        case $terminal in
+            termite)
+                if (( $# > 0 )); then
+                    exec $terminal -e "${*:2}"
+                else
+                    exec $terminal
+                fi
+                ;;
+            *)
+                exec $terminal "$@"
+                ;;
+        esac
     fi
 done
 


### PR DESCRIPTION
When using the '-e' flag, termite expects that the program to be run and
all its arguments will be passed as a single string argument, which is
unlike some other terminals. Because of this, rofi-sensible-terminal was
broken for termite, e.g. trying to connect to a host using rofi -show ssh
doesn't open a terminal successfully.