### PR TITLE
Put Xfwm4 on the WM list that needs extra desktop change.

### DIFF
--- a/include/xcb.h
+++ b/include/xcb.h
@@ -174,7 +174,9 @@ typedef enum
     /** Awesome window manager */
     WM_AWESOME = 2,
     /** Openbox window manager */
-    WM_OPENBOX = 4
+    WM_OPENBOX = 4,
+    /** Xfwm4 */
+    WM_XFWM4   = 8,
 } WindowManager;
 
 /**

--- a/source/dialogs/window.c
+++ b/source/dialogs/window.c
@@ -584,7 +584,7 @@ static ModeMode window_mode_result ( Mode *sw, int mretv, G_GNUC_UNUSED char **i
         }
         else {
             rofi_view_hide ();
-            if ( ( current_window_manager & ( WM_AWESOME | WM_OPENBOX ) ) != 0 ) {
+            if ( ( current_window_manager & ( WM_AWESOME | WM_OPENBOX | WM_XFWM4 ) ) != 0 ) {
                 // Get the desktop of the client to switch to
                 uint32_t                  wmdesktop = 0;
                 xcb_get_property_cookie_t cookie;

--- a/source/xcb.c
+++ b/source/xcb.c
@@ -885,6 +885,9 @@ static void x11_helper_discover_window_manager ( void )
                 else if  ( g_strcmp0 ( wtitle.strings, "Openbox" ) == 0 ) {
                     current_window_manager = WM_OPENBOX;
                 }
+                else if ( g_strcmp0 ( wtitle.strings, "Xfwm4" ) == 0 ) {
+                    current_window_manager = WM_XFWM4;
+                }
             }
             xcb_ewmh_get_utf8_strings_reply_wipe ( &wtitle );
         }


### PR DESCRIPTION
Work-around that makes sure desktop gets switchs when setting active
window.

Fixes: #624