### PR TITLE
Add new "start" matching method

### DIFF
--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -213,6 +213,7 @@ Specify the matching algorithm used.
 Current the following methods are supported.
 
 * **normal**: match the int string
+* **start**: Match at the start of the string.
 * **regex**: match a regex input
 * **glob**: match a glob pattern
 * **fuzzy**: do a fuzzy match

--- a/include/settings.h
+++ b/include/settings.h
@@ -40,7 +40,8 @@ typedef enum
     MM_NORMAL = 0,
     MM_REGEX  = 1,
     MM_GLOB   = 2,
-    MM_FUZZY  = 3
+    MM_FUZZY  = 3,
+    MM_START  = 4
 } MatchingMethod;
 
 /**

--- a/source/helper.c
+++ b/source/helper.c
@@ -244,6 +244,11 @@ static rofi_int_matcher * create_regex ( const char *input, int case_sensitive )
         retv = R ( r, case_sensitive );
         g_free ( r );
         break;
+    case MM_START: 
+        r    = g_regex_escape_string ( input, -1 );
+        retv = R ( g_strconcat ( "^", r, (char *) NULL ), case_sensitive );
+        g_free ( r );
+        break;
     default:
         r    = g_regex_escape_string ( input, -1 );
         retv = R ( r, case_sensitive );
@@ -588,10 +593,13 @@ int config_sanity_check ( void )
             config.matching_method = MM_FUZZY;
         }
         else if ( g_strcmp0 ( config.matching, "normal" ) == 0 ) {
-            config.matching_method = MM_NORMAL;;
+            config.matching_method = MM_NORMAL;
+        }
+        else if ( g_strcmp0 ( config.matching, "start" ) == 0 ) {
+            config.matching_method = MM_START;
         }
         else {
-            g_string_append_printf ( msg, "\t<b>config.matching</b>=%s is not a valid matching strategy.\nValid options are: glob, regex, fuzzy or normal.\n",
+            g_string_append_printf ( msg, "\t<b>config.matching</b>=%s is not a valid matching strategy.\nValid options are: glob, regex, fuzzy, start or normal.\n",
                                      config.matching );
             found_error = 1;
         }

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -158,7 +158,7 @@ static XrmOption xrmOptions[] = {
     { xrm_String,  "combi-modi",             { .str  = &config.combi_modi                     }, NULL,
       "Set the modi to combine in combi mode", CONFIG_DEFAULT },
     { xrm_String,  "matching",               { .str  = &config.matching                       }, NULL,
-      "Set the matching algorithm. (normal, regex, glob, fuzzy)", CONFIG_DEFAULT },
+      "Set the matching algorithm. (normal, start, regex, glob, fuzzy)", CONFIG_DEFAULT },
     { xrm_Boolean, "tokenize",               { .num  = &config.tokenize                       }, NULL,
       "Tokenize input string", CONFIG_DEFAULT },
     { xrm_String,  "monitor",                { .str  = &config.monitor                        }, NULL,

--- a/test/helper-tokenize.c
+++ b/test/helper-tokenize.c
@@ -423,6 +423,40 @@ START_TEST ( test_tokenizer_match_regex_single_two_word_till_end )
 }
 END_TEST
 
+START_TEST ( test_tokenizer_match_start )
+    config.matching_method = MM_START;
+    GRegex **tokens = tokenize ( "noot", FALSE );
+
+    TASSERT ( helper_token_match ( tokens, "aap noot mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "aap mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "nooaap mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "nootap mies") == TRUE );
+    TASSERT ( helper_token_match ( tokens, "aap Noot mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "Nooaap mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "noOTap mies") == TRUE );
+
+    tokenize_free ( tokens );
+
+    tokens = tokenize ( "noot", TRUE );
+
+    TASSERT ( helper_token_match ( tokens, "aap noot mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "aap mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "nooaap mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "nootap mies") == TRUE );
+    TASSERT ( helper_token_match ( tokens, "aap Noot mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "Nooaap mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "noOTap mies") == FALSE );
+
+    tokenize_free ( tokens );
+    tokens = tokenize ( "no ot", FALSE );
+    TASSERT ( helper_token_match ( tokens, "aap noot mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "aap mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "nooaap mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "nootap mies") == FALSE );
+    TASSERT ( helper_token_match ( tokens, "noap miesot") == FALSE );
+    tokenize_free ( tokens );
+END_TEST
+
 static Suite * helper_tokenizer_suite (void)
 {
     Suite *s;
@@ -474,6 +508,11 @@ static Suite * helper_tokenizer_suite (void)
         tcase_add_test(tc_regex, test_tokenizer_match_regex_multiple_ci);
         suite_add_tcase(s, tc_regex);
     }
+    {
+        TCase *tc_regex = tcase_create ("Start");
+        tcase_add_test(tc_regex, test_tokenizer_match_start);
+        suite_add_tcase(s, tc_start);
+    }
 
 
     return s;
@@ -497,5 +536,4 @@ int main ( G_GNUC_UNUSED int argc, G_GNUC_UNUSED char ** argv )
     number_failed = srunner_ntests_failed(sr);
     srunner_free(sr);
     return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
-    
 }


### PR DESCRIPTION
This is similar to "normal", except that it will only match the *start* of
strings.

For example, using `rofi -show run -matching normal` and then typing `pid` on my
system shows (in this order):

	acpid
	pidgin
	pidof

But with `-matching start` it's:

	pidgin
	pidof

Many more examples where the output is much more useful, IMHO.

Could also use `matching regex` and `^pid`, but that's one extra character of
typing I need to do for ever `rofi` invocation, *and* I'd then have to worry
about escaping regexps, which I'd rather not do.