### PR TITLE
Add warning about outdated version under Ubuntu 16.04 Xenial

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -184,8 +184,13 @@ gdb rofi core
 
 ```
 apt install rofi
-
 ```
+
+#### Ubuntu 16.04 Xenial
+
+**Please note that the latest version of rofi in Ubuntu 16.04 is extremly outdated (v0.15.11)** 
+
+This will cause issues with newer scripts (i.e. with clerk) and we recommend to manually download and install the deb file for zesty instead. You can find the deb on [ubuntu's launchpad page for rofi](https://launchpad.net/ubuntu/+source/rofi).
 
 ### Fedora
 


### PR DESCRIPTION
Ubuntu 16.04 packaged version of rofi is extremely outdated. This causes
all kind of weird behaviour with newer scripts, i.e. with clerk.
This commit adds a warning to the installation instructions to warn new
users about this problem and direct them to install a newer version
directly from launchpad.

Hope that this remark will save people some trouble.