### PR TITLE
Add icon-size option

### DIFF
--- a/config/config.c
+++ b/config/config.c
@@ -53,6 +53,8 @@ Settings config = {
 
     /** Whether to load and show icons */
     .show_icons          = FALSE,
+    /** Icon size */
+    .icon_size           = 0,
 
     /** Terminal to use. (for ssh and open in terminal) */
     .terminal_emulator = "rofi-sensible-terminal",

--- a/doc/test_xr.txt
+++ b/doc/test_xr.txt
@@ -22,6 +22,8 @@ rofi.xoffset:                        0
 rofi.fixed-num-lines:                true
 ! "Whether to load and show icons" Set from: Default
 ! rofi.show-icons:                     false
+! "Icon size" Set from: Default
+! rofi.icon-size:                      0
 ! "Terminal to use" Set from: File
 rofi.terminal:                       sakura
 ! "Ssh client to use" Set from: File

--- a/include/settings.h
+++ b/include/settings.h
@@ -70,6 +70,8 @@ typedef struct
 
     /** Whether to load and show icons  */
     gboolean       show_icons;
+    /** Icon size */
+    unsigned int   icon_size;
 
     /** Terminal to use  */
     char           * terminal_emulator;

--- a/source/view.c
+++ b/source/view.c
@@ -932,7 +932,7 @@ static void update_callback ( textbox *t, unsigned int index, void *udata, TextB
         else{
             list = pango_attr_list_new ();
         }
-        int             icon_height = textbox_get_font_height ( t );
+        int icon_height = config.icon_size ? config.icon_size : textbox_get_font_height ( t );
 
         cairo_surface_t *icon = mode_get_icon ( state->sw, state->line_map[index], icon_height );
         textbox_icon ( t, icon );

--- a/source/widgets/textbox.c
+++ b/source/widgets/textbox.c
@@ -40,6 +40,7 @@
 #include "view.h"
 
 #include "theme.h"
+#include "settings.h"
 
 #define DOT_OFFSET    15
 
@@ -431,8 +432,8 @@ static void textbox_draw ( widget *wid, cairo_t *draw )
         int    iconh = cairo_image_surface_get_height ( tb->icon );
         int    iconw = cairo_image_surface_get_width ( tb->icon );
         int    icons = MAX ( iconh, iconw );
-        double scale = (double) iconheight / icons;
-        cairo_translate ( draw, x + ( iconheight - iconw * scale ) / 2.0, y + ( iconheight - iconh * scale ) / 2.0 );
+        double scale = (double) (config.icon_size ? config.icon_size : iconheight) / icons;
+        cairo_translate ( draw, round ( x + ( iconheight - iconw * scale ) / 2.0 ), round ( y + ( iconheight - iconh * scale ) / 2.0 ) );
         cairo_scale ( draw, scale, scale );
         cairo_set_source_surface ( draw, tb->icon, 0, 0 );
         cairo_paint ( draw );

--- a/source/widgets/textbox.c
+++ b/source/widgets/textbox.c
@@ -432,7 +432,7 @@ static void textbox_draw ( widget *wid, cairo_t *draw )
         int    iconh = cairo_image_surface_get_height ( tb->icon );
         int    iconw = cairo_image_surface_get_width ( tb->icon );
         int    icons = MAX ( iconh, iconw );
-        double scale = (double) (config.icon_size ? config.icon_size : iconheight) / icons;
+        double scale = (double) (config.icon_size ? MIN ( iconheight, config.icon_size ) : iconheight) / icons;
         cairo_translate ( draw, round ( x + ( iconheight - iconw * scale ) / 2.0 ), round ( y + ( iconheight - iconh * scale ) / 2.0 ) );
         cairo_scale ( draw, scale, scale );
         cairo_set_source_surface ( draw, tb->icon, 0, 0 );

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -113,6 +113,8 @@ static XrmOption xrmOptions[] = {
 
     { xrm_Boolean, "show-icons",          { .snum = &config.show_icons                     }, NULL,
       "Whether to load and show icons", CONFIG_DEFAULT },
+    { xrm_Number,  "icon-size",           { .num = &config.icon_size                       }, NULL,
+      "Icon size", CONFIG_DEFAULT },
 
     { xrm_String,  "terminal",            { .str  = &config.terminal_emulator              }, NULL,
       "Terminal to use", CONFIG_DEFAULT },


### PR DESCRIPTION
This option is useful to prevent blurry icons. The new option is optional and
by default icons are still scaled to fill all available space.