### PR TITLE
Fix errors in example themes in docs

### DIFF
--- a/doc/rofi-theme.5
+++ b/doc/rofi-theme.5
@@ -142,7 +142,7 @@ This is a valid element name:
 .
 .nf
 
-element normal\.normal {
+#element normal\.normal {
     background\-color: blue;
 }
 button {
@@ -160,7 +160,7 @@ And is identical to:
 .
 .nf
 
-element normal normal, button {
+#element normal normal, button {
     background\-color: blue;
 }
 .
@@ -746,7 +746,7 @@ For example:
 .
 .nf
 
-element selected {
+#element selected {
 }
 .
 .fi
@@ -763,11 +763,11 @@ The difference between dots and spaces is purely cosmetic\. These are all the sa
 .
 .nf
 
-element \.selected {
+#element \.selected {
 
-element\.selected {
+#element\.selected {
 }
-element selected {
+#element selected {
 }
 .
 .fi

--- a/doc/rofi-theme.5
+++ b/doc/rofi-theme.5
@@ -175,11 +175,11 @@ Each section inherits the global properties\. Properties can be explicitely inhe
 .
 .nf
 
-window {
+#window {
  a: 1;
  b: 2;
 }
-mainbox {
+#mainbox {
     a: inherit;
     b: 4;
     c: 8;
@@ -1152,7 +1152,7 @@ Below is an example of a theme emulating dmenu:
     font:            "Times New Roman 12";
 }
 
-window {
+#window {
     anchor:     north;
     location:   north;
     width:      100%;
@@ -1160,26 +1160,26 @@ window {
     children:   [ horibox ];
 }
 
-horibox {
+#horibox {
     orientation: horizontal;
     children:   [ prompt, entry, listview ];
 }
 
-listview {
+#listview {
     layout:     horizontal;
     spacing:    5px;
     lines:      10;
 }
 
-entry {
+#entry {
     expand:     false;
     width:      10em;
 }
 
-element {
+#element {
     padding: 0px 2px;
 }
-element selected {
+#element selected {
     background\-color: SteelBlue;
 }
 .

--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -134,11 +134,11 @@ Each section inherits the global properties. Properties can be explicitely inher
 In the following example:
 
 ```
-window {
+#window {
  a: 1;
  b: 2;
 }
-mainbox {
+#mainbox {
     a: inherit;
     b: 4;
     c: 8;
@@ -739,7 +739,7 @@ Below is an example of a theme emulating dmenu:
     font:            "Times New Roman 12";
 }
 
-window {
+#window {
     anchor:     north;
     location:   north;
     width:      100%;
@@ -747,26 +747,26 @@ window {
     children:   [ horibox ];
 }
 
-horibox {
+#horibox {
     orientation: horizontal;
     children:   [ prompt, entry, listview ];
 }
 
-listview {
+#listview {
     layout:     horizontal;
     spacing:    5px;
     lines:      10;
 }
 
-entry {
+#entry {
     expand:     false;
     width:      10em;
 }
 
-element {
+#element {
     padding: 0px 2px;
 }
-element selected {
+#element selected {
     background-color: SteelBlue;
 }
 ```

--- a/doc/rofi-theme.5.markdown
+++ b/doc/rofi-theme.5.markdown
@@ -113,7 +113,7 @@ Multiple elements can be specified by a `,`.
 This is a valid element name:
 
 ```
-element normal.normal {
+#element normal.normal {
     background-color: blue;
 }
 button {
@@ -124,7 +124,7 @@ button {
 And is identical to:
 
 ```
-element normal normal, button {
+#element normal normal, button {
     background-color: blue;
 }
 ```
@@ -464,7 +464,7 @@ Some widgets have an extra state.
 For example:
 
 ```
-element selected {
+#element selected {
 }
 ```
 
@@ -473,11 +473,11 @@ Here `element selected` is the name of the widget, `selected` is the state of th
 The difference between dots and spaces is purely cosmetic. These are all the same:
 
 ```
-element .selected {
+#element .selected {
 
-element.selected {
+#element.selected {
 }
-element selected {
+#element selected {
 }
 ```
 


### PR DESCRIPTION
In 1.4.2, these themes don't compile, and I'm presented with parser errors.

This fixes that.