### PR TITLE
changed ligbwater's url from git to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libgwater"]
 	path = subprojects/libgwater
-	url = git://github.com/sardemff7/libgwater
+	url = https://github.com/sardemff7/libgwater
 [submodule "libnkutils"]
 	path = subprojects/libnkutils
 	url = https://github.com/sardemff7/libnkutils


### PR DESCRIPTION
I changed this because it gives a warning during compilation on Gentoo : 

> git-r3: git protocol is completely unsecure and may render the ebuild
> easily susceptible to MITM attacks (even if used only as fallback). Please
> use https instead.
> [URI: git://github.com/sardemff7/libgwater]