### PR TITLE
Add some additional info on installing on 16.04

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -191,7 +191,7 @@ apt install rofi
 
 **Please note that the latest version of rofi in Ubuntu 16.04 is extremely outdated (v0.15.11)** 
 
-This will cause issues with newer scripts (i.e. with clerk) and we recommend to manually download and install the deb file for zesty instead. You can find the deb on [ubuntu's launchpad page for rofi](https://launchpad.net/ubuntu/+source/rofi).
+This will cause issues with newer scripts (i.e. with clerk) and we recommend to manually download and install newer deb files for rofi and dependencies from Zesty instead. You can find the rofi deb on [ubuntu's launchpad page for rofi](https://launchpad.net/ubuntu/+source/rofi) and you will also need [xcb-util-xrm](https://launchpad.net/ubuntu/+source/xcb-util-xrm) and a newer [libxkbcommon](https://launchpad.net/ubuntu/+source/libxkbcommon). First install the dependencies using `sudo dpkg -i <each-package-name>.deb` and then you should be able to `sudo dpkg -i rofi*.deb` and enjoy the features of the latest version.
 
 ### Fedora
 


### PR DESCRIPTION
I went to follow the directions and they didn't let me install the newest or even prior versions of rofi until I found xcb-util-xrm higher up in the compiling instructions after reading a couple other issues. This should make it more evident to users how to get it working.