### PR TITLE
commandline option to specify the location of the applications directory for drun mode

### DIFF
--- a/config/config.c
+++ b/config/config.c
@@ -67,6 +67,8 @@ Settings config = {
     .run_shell_command      = "{terminal} -e {cmd}",
     /** Command executed on accep-entry-custom for window modus */
     .window_command         = "xkill -id {window}",
+    /** User's specified paths for Desktop entries */
+    .drun_apps_dir          = NULL,
     /** No default icon theme, we search Adwaita and gnome as fallback */
     .drun_icon_theme        = NULL,
     /**

--- a/doc/rofi.1
+++ b/doc/rofi.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ROFI" "1" "December 2017" "" ""
+.TH "ROFI" "1" "January 2018" "" ""
 .
 .SH "NAME"
 \fBrofi\fR \- A window switcher, application launcher, ssh dialog and dmenu replacement
@@ -351,6 +351,12 @@ Show application icons in drun and window modes\.
 .
 .P
 Specify icon theme to be used in drun mode if show\-icons setting is enabled\. If not specified default theme from DE is used, \fIAdwaita\fR and \fIgnome\fR themes act as fallback themes\.
+.
+.P
+\fB\-drun\-apps\-dir\fR \fIdirectory\fR
+.
+.P
+Specify Desktop entries location to be used in drun mode\. If this option specified, Desktop entries will be used only from \fIapplications\fR subdirectory of \fIdirectory\fR\. Optionally the \fIdirectory\fR may content \fIicons\fR or/and \fIpixmaps\fR subdirectories\. If the environment variable XDG_DATA_HOME is set to \fIdirectory\fR, then the icons will be used from \fIicons\fR or/and \fIpixmaps\fR subdirectories\.
 .
 .SS "Matching"
 \fB\-matching\fR \fImethod\fR

--- a/doc/rofi.1.markdown
+++ b/doc/rofi.1.markdown
@@ -205,6 +205,13 @@ Specify icon theme to be used in drun mode if show-icons setting is enabled.
 If not specified default theme from DE is used, *Adwaita* and *gnome* themes act as
 fallback themes.
 
+`-drun-apps-dir` *directory*
+
+Specify Desktop entries location to be used in drun mode.
+If this option specified, Desktop entries will be used only from *applications* subdirectory of *directory*.
+Optionally the *directory* may content *icons* or/and *pixmaps* subdirectories. If the environment variable
+XDG_DATA_HOME is set to *directory*, then the icons will be used from *icons* or/and *pixmaps* subdirectories.
+
 ### Matching
 
 `-matching` *method*

--- a/include/settings.h
+++ b/include/settings.h
@@ -89,6 +89,8 @@ typedef struct
     char           * window_match_fields;
     /** Theme for icons */
     char           * drun_icon_theme;
+    /** User's specified path's for Desktop entries */
+    char           * drun_apps_dir;
 
     /** Windows location/gravity */
     WindowLocation location;

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -130,6 +130,8 @@ static XrmOption xrmOptions[] = {
       "Command executed on accep-entry-custom for window modus", CONFIG_DEFAULT },
     { xrm_String,  "window-match-fields",    { .str  = &config.window_match_fields            }, NULL,
       "Window fields to match in window mode", CONFIG_DEFAULT },
+    { xrm_String,  "drun-apps-dir",          { .str  = &config.drun_apps_dir                  }, NULL,
+      "User's Desktop entries", CONFIG_DEFAULT },
     { xrm_String,  "drun-icon-theme",        { .str  = &config.drun_icon_theme                }, NULL,
       "Theme to use to look for icons", CONFIG_DEFAULT },
 


### PR DESCRIPTION
Added "drun-apps-dir" commandline option to specify the location of the Desktop entries for drun mode.
This option may be convenient for systems without DE (WM only) for emulation of desktop shortcuts.