### PR TITLE
Update config file location in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ For the full list of key bindings, see: `rofi -show keys` or `rofi -help`.
 
 There are currently three methods of setting configuration options:
 
- * Local configuration. Normally, depending on XDG, in `~/.local/rofi/config`. This uses the Xresources format.
+ * Local configuration. Normally, depending on XDG, in `~/.config/rofi/config`. This uses the Xresources format.
  * Xresources: A method of storing key values in the Xserver. See
    [here](https://en.wikipedia.org/wiki/X_resources) for more information.
  * Command line options: Arguments are passed to **Rofi**.


### PR DESCRIPTION
I couldn't get the configuration file to work in `~/.local` but it did work in `~/.config`. This might be distro specific but I believe it is the norm now.