### PR TITLE
Add history ignore

### DIFF
--- a/config/config.c
+++ b/config/config.c
@@ -92,7 +92,7 @@ Settings config = {
     /** Do not use history */
     .disable_history        = FALSE,
     /** Programs ignored for history */
-    .ignored_programs       = "",
+    .ignored_prefixes       = "",
     /** Sort the displayed list */
     .sort                   = FALSE,
     /** Use levenshtein sorting when matching */

--- a/config/config.c
+++ b/config/config.c
@@ -91,6 +91,8 @@ Settings config = {
     .fixed_num_lines        = TRUE,
     /** Do not use history */
     .disable_history        = FALSE,
+    /** Programs ignored for history */
+    .ignored_programs       = "",
     /** Sort the displayed list */
     .sort                   = FALSE,
     /** Use levenshtein sorting when matching */

--- a/include/history.h
+++ b/include/history.h
@@ -36,7 +36,7 @@
  *
  * This uses the following options from the #config object:
  * * #Settings::disable_history
- * * #Settings::ignored_programs
+ * * #Settings::ignored_prefixes
  *
  * @{
  */

--- a/include/history.h
+++ b/include/history.h
@@ -36,6 +36,7 @@
  *
  * This uses the following options from the #config object:
  * * #Settings::disable_history
+ * * #Settings::ignored_programs
  *
  * @{
  */

--- a/include/settings.h
+++ b/include/settings.h
@@ -108,6 +108,8 @@ typedef struct
     unsigned int   fixed_num_lines;
     /** Do not use history */
     unsigned int   disable_history;
+    /** Programs ignored for history */
+    char           * ignored_programs;
     /** Toggle to enable sorting. */
     unsigned int   sort;
     /** Sorting method. */

--- a/include/settings.h
+++ b/include/settings.h
@@ -109,7 +109,7 @@ typedef struct
     /** Do not use history */
     unsigned int   disable_history;
     /** Programs ignored for history */
-    char           * ignored_programs;
+    char           * ignored_prefixes;
     /** Toggle to enable sorting. */
     unsigned int   sort;
     /** Sorting method. */

--- a/source/history.c
+++ b/source/history.c
@@ -185,21 +185,12 @@ void history_set ( const char *filename, const char *entry )
     for ( char *checked_prefix = strtok ( config.ignored_prefixes, ";" ); checked_prefix != NULL; checked_prefix = strtok ( NULL, ";" ) ) {
         // For each ignored prefix
 
-        if ( checked_prefix[0] == ' ' ) {
-            checked_prefix++;                            // Some users will probably want "; " as their separator for aesthetics.
+        while ( g_unichar_isspace ( g_utf8_get_char ( checked_prefix ) ) ) {
+            checked_prefix = g_utf8_next_char ( checked_prefix ); // Some users will probably want "; " as their separator for aesthetics.
         }
-        if ( strlen ( entry ) < strlen ( checked_prefix ) ) {
-            continue;                                          // Cannot be a prefix if it's longer.
-        }
-        for ( int i = 0; i < strlen ( checked_prefix ); ++i ) {
-            // For each character in the prefix
 
-            if ( checked_prefix[i] != entry[i] ) {
-                break;                                 // Break from the loop on the first unidentical character.
-            }
-            if ( i == strlen ( checked_prefix ) - 1 ) {
-                return;                                   // If we've reached the last letter and did not break, return.
-            }
+        if ( g_str_has_prefix ( entry, checked_prefix ) ) {
+            return;
         }
     }
 

--- a/source/history.c
+++ b/source/history.c
@@ -182,12 +182,24 @@ void history_set ( const char *filename, const char *entry )
     }
 
     // Check if program should be ignored
-    gchar *program = g_newa ( gchar, strlen ( entry ) + 1 );
-    strcpy ( program, entry );
-    program = strtok ( program, " " );  // Name of the executable
-    for ( char *current_ignored = strtok ( config.ignored_programs, ", " ); current_ignored != NULL; current_ignored = strtok ( NULL, ", " ) ) {
-        if ( strcmp ( current_ignored, program ) == 0 ) {
-            return;
+    for ( char *checked_prefix = strtok ( config.ignored_programs, ";" ); checked_prefix != NULL; checked_prefix = strtok ( NULL, ";" ) ) {
+        // For each ignored prefix
+
+        if ( checked_prefix[0] == ' ' ) {
+            checked_prefix++;                            // Some users will probably want "; " as their separator for aesthetics.
+        }
+        if ( strlen ( entry ) < strlen ( checked_prefix ) ) {
+            continue;                                          // Cannot be a prefix if it's longer.
+        }
+        for ( int i = 0; i < strlen ( checked_prefix ); ++i ) {
+            // For each character in the prefix
+
+            if ( checked_prefix[i] != entry[i] ) {
+                break;                                 // Break from the loop on the first unidentical character.
+            }
+            if ( i == strlen ( checked_prefix ) - 1 ) {
+                return;                                   // If we've reached the last letter and did not break, return.
+            }
         }
     }
 

--- a/source/history.c
+++ b/source/history.c
@@ -180,6 +180,17 @@ void history_set ( const char *filename, const char *entry )
     if ( config.disable_history ) {
         return;
     }
+
+    // Check if program should be ignored
+    char *program = malloc ( sizeof ( char ) * strlen ( entry ) + 1 );
+    strcpy ( program, entry );
+    program = strtok ( program, " " );  // Name of the executable
+    for ( char *current_ignored = strtok ( config.ignored_programs, ", " ); current_ignored != NULL; current_ignored = strtok ( NULL, ", " ) ) {
+        if ( strcmp ( current_ignored, program ) == 0 ) {
+            return;
+        }
+    }
+
     int          found  = 0;
     unsigned int curr   = 0;
     unsigned int length = 0;

--- a/source/history.c
+++ b/source/history.c
@@ -182,7 +182,7 @@ void history_set ( const char *filename, const char *entry )
     }
 
     // Check if program should be ignored
-    for ( char *checked_prefix = strtok ( config.ignored_programs, ";" ); checked_prefix != NULL; checked_prefix = strtok ( NULL, ";" ) ) {
+    for ( char *checked_prefix = strtok ( config.ignored_prefixes, ";" ); checked_prefix != NULL; checked_prefix = strtok ( NULL, ";" ) ) {
         // For each ignored prefix
 
         if ( checked_prefix[0] == ' ' ) {

--- a/source/history.c
+++ b/source/history.c
@@ -182,7 +182,7 @@ void history_set ( const char *filename, const char *entry )
     }
 
     // Check if program should be ignored
-    char *program = malloc ( sizeof ( char ) * strlen ( entry ) + 1 );
+    gchar *program = g_newa ( gchar, strlen ( entry ) + 1 );
     strcpy ( program, entry );
     program = strtok ( program, " " );  // Name of the executable
     for ( char *current_ignored = strtok ( config.ignored_programs, ", " ); current_ignored != NULL; current_ignored = strtok ( NULL, ", " ) ) {

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -139,7 +139,7 @@ static XrmOption xrmOptions[] = {
       "Desktop entry show actions.", CONFIG_DEFAULT },
     { xrm_Boolean, "disable-history",        { .num  = &config.disable_history                }, NULL,
       "Disable history in run/ssh", CONFIG_DEFAULT },
-    { xrm_String,  "ignored-programs",       { .str  = &config.ignored_programs               }, NULL,
+    { xrm_String,  "ignored-prefixes",       { .str  = &config.ignored_prefixes               }, NULL,
       "Programs ignored for history", CONFIG_DEFAULT },
     { xrm_Boolean, "sort",                   { .num  = &config.sort                           }, NULL,
       "Use sorting", CONFIG_DEFAULT },

--- a/source/xrmoptions.c
+++ b/source/xrmoptions.c
@@ -139,6 +139,8 @@ static XrmOption xrmOptions[] = {
       "Desktop entry show actions.", CONFIG_DEFAULT },
     { xrm_Boolean, "disable-history",        { .num  = &config.disable_history                }, NULL,
       "Disable history in run/ssh", CONFIG_DEFAULT },
+    { xrm_String,  "ignored-programs",       { .str  = &config.ignored_programs               }, NULL,
+      "Programs ignored for history", CONFIG_DEFAULT },
     { xrm_Boolean, "sort",                   { .num  = &config.sort                           }, NULL,
       "Use sorting", CONFIG_DEFAULT },
     { xrm_String,  "sorting-method",         { .str  = &config.sorting_method                 }, NULL,


### PR DESCRIPTION
This allows for configuring certain programs/executables that will not be added to the history file.
To use it, create an entry rofi.ignored-programs in the config file, and a list of space or colon (or both) separated values. For example:
```
rofi.ignored-programs: jts =
```
Then, upon running rofi and running a command that starts with one of these words (`jts` or `=`) it will not be added to the history file.

Useful for stuff such as calculations (using `=`) which you may not want to keep in your history file, or other commands that you do not want autocompleted past the command stage (`jts`, in my case, is a script that jumps to a song in my media player)