### PR TITLE
tests: initialize char* in mode test

### DIFF
--- a/source/mode.c
+++ b/source/mode.c
@@ -98,7 +98,7 @@ ModeMode mode_result ( Mode *mode, int menu_retv, char **input, unsigned int sel
 {
     g_assert ( mode != NULL );
     g_assert ( mode->_result != NULL );
-    g_assert ( ( *input ) != NULL );
+    g_assert ( input != NULL );
     return mode->_result ( mode, menu_retv, input, selected_line );
 }
 

--- a/test/mode-test.c
+++ b/test/mode-test.c
@@ -135,7 +135,7 @@ END_TEST
 
 START_TEST(test_mode_result)
 {
-    const char *res = "";
+    char res[] = "";
     ck_assert_int_eq ( mode_result ( &help_keys_mode, MENU_NEXT, &res,0), NEXT_DIALOG);
     ck_assert_int_eq ( mode_result ( &help_keys_mode, MENU_PREVIOUS, &res,0), PREVIOUS_DIALOG);
     ck_assert_int_eq ( mode_result ( &help_keys_mode, MENU_QUICK_SWITCH|1, &res,0), 1);

--- a/test/mode-test.c
+++ b/test/mode-test.c
@@ -135,7 +135,7 @@ END_TEST
 
 START_TEST(test_mode_result)
 {
-    char *res;
+    const char *res = "";
     ck_assert_int_eq ( mode_result ( &help_keys_mode, MENU_NEXT, &res,0), NEXT_DIALOG);
     ck_assert_int_eq ( mode_result ( &help_keys_mode, MENU_PREVIOUS, &res,0), PREVIOUS_DIALOG);
     ck_assert_int_eq ( mode_result ( &help_keys_mode, MENU_QUICK_SWITCH|1, &res,0), 1);


### PR DESCRIPTION
Currently, test_mode_result relies on undefined behavior.
The test calls mode_result, which checks whether the pointer is NULL.
However, the pointer was never initialized, so it may or may not be
NULL, depending on the compiler.

This caused a test failure on ppc64 and Fedora 28, apparently because in
this setting, gcc sets uninitialized pointers to NULL.

By initializing the pointer to the empty string, the behavior is defined
and the test passes on all architectures.

I also started adding const qualifiers to all input `char**`, but that is more involved than I expected, so I stopped half-way. If you're interested, I can finish that up.