### PR TITLE
Fix RandR 1.5 check: use RANDR_PREF_MINOR_VERSION

### DIFF
--- a/source/xcb.c
+++ b/source/xcb.c
@@ -362,8 +362,8 @@ static void x11_build_monitor_layout ()
     if ( rversion ) {
         g_debug ( "Found randr version: %d.%d", rversion->major_version, rversion->minor_version );
         // Check if we are 1.5 and up.
-        if ( ( ( rversion->major_version == XCB_RANDR_MAJOR_VERSION ) && ( rversion->minor_version >= XCB_RANDR_MINOR_VERSION ) ) ||
-             ( rversion->major_version > XCB_RANDR_MAJOR_VERSION ) ) {
+        if ( ( ( rversion->major_version == RANDR_PREF_MAJOR_VERSION ) && ( rversion->minor_version >= RANDR_PREF_MINOR_VERSION ) ) ||
+             ( rversion->major_version > RANDR_PREF_MAJOR_VERSION ) ) {
             xcb_randr_get_monitors_cookie_t t       = xcb_randr_get_monitors ( xcb->connection, xcb->screen->root, 1 );
             xcb_randr_get_monitors_reply_t  *mreply = xcb_randr_get_monitors_reply ( xcb->connection, t, NULL );
             if ( mreply ) {


### PR DESCRIPTION
XCB_RANDR_MAJOR_VERSION/XCB_RANDR_MINOR_VERSION are the maximum supported (in code) version.

Before this commit, the check verified that your libxcb did not support a newer RandR version than your running server.
After this commit, the check verifies the server’s RandR version is at least 1.5.